### PR TITLE
KZL-547 - update validateSpecification signature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 install:
   - pip install awscli --upgrade --user
 
-before_deploy:
+after_success:
   - docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make package
 
 deploy:
@@ -37,7 +37,7 @@ deploy:
   local-dir: deploy
   on:
     all_branches: true
-    condition: $TRAVIS_BRANCH =~ ^master|*-dev$
+    condition: branch = master OR branch =~ ^.?-dev$
 
 after_deploy:
   - aws cloudfront create-invalidation --distribution-id $AWS_CLOUDFRONT_DISTRIBUTION_ID --paths "/*"

--- a/cgo/kuzzle/collection.go
+++ b/cgo/kuzzle/collection.go
@@ -125,15 +125,15 @@ func kuzzle_collection_search_specifications(c *C.collection, options *C.query_o
 }
 
 //export kuzzle_collection_update_specifications
-func kuzzle_collection_update_specifications(c *C.collection, index *C.char, col *C.char, body *C.char, options *C.query_options) *C.string_result {
-	res, err := (*collection.Collection)(c.instance).UpdateSpecifications(C.GoString(index), C.GoString(col), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
+func kuzzle_collection_update_specifications(c *C.collection, index *C.char, col *C.char, specifications *C.char, options *C.query_options) *C.string_result {
+	res, err := (*collection.Collection)(c.instance).UpdateSpecifications(C.GoString(index), C.GoString(col), json.RawMessage(C.GoString(specifications)), SetQueryOptions(options))
 	var stringResult string
 	stringResult = string(res)
 	return goToCStringResult(&stringResult, err)
 }
 
 //export kuzzle_collection_validate_specifications
-func kuzzle_collection_validate_specifications(c *C.collection, body *C.char, options *C.query_options) *C.validation_response {
-	res, err := (*collection.Collection)(c.instance).ValidateSpecifications(json.RawMessage(C.GoString(body)), SetQueryOptions(options))
+func kuzzle_collection_validate_specifications(c *C.collection, index *C.char, col *C.char, specifications *C.char, options *C.query_options) *C.validation_response {
+	res, err := (*collection.Collection)(c.instance).ValidateSpecifications(C.GoString(index), C.GoString(col), json.RawMessage(C.GoString(specifications)), SetQueryOptions(options))
 	return goToCValidationResponse(res, err)
 }


### PR DESCRIPTION
## What does this PR do?

Before the method `ValidateSpecifications` didn't take an index an a collection in parameters and could be used for any collection.  
This PR change the signature to match the rest of the collection controller. The method now take an index and a collection in addition to the specifications for this collection.

I also modify the `UpdateSpecifications` method. The method was taking an index and collection in parameter but it didn't scope the specifications to the collection. 

Related PR: https://github.com/kuzzleio/sdk-javascript/pull/318, https://github.com/kuzzleio/sdk-go/pull/211, https://github.com/kuzzleio/sdk-c/pull/13, https://github.com/kuzzleio/sdk-cpp/pull/11, https://github.com/kuzzleio/sdk-java/pull/13, https://github.com/kuzzleio/documentation-V2/pull/51
### How should this be manually tested?

  - Step 1: Build the SDK `docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make`