### PR TITLE
Add default room options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,5 +11,5 @@ You can use the `align-submodules.sh` script to achieve this. (e.g. `./align-sub
 
 You can use this Docker image to build the SDK:  
 ```
-docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make
+docker run --rm -it -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all
 ```

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -119,8 +119,10 @@ func kuzzle_free_room_options(st *C.room_options) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.scope))
 		C.free(unsafe.Pointer(st.state))
-		C.free(unsafe.Pointer(st.user))
-		C.free(unsafe.Pointer(st.volatiles))
+		C.free(unsafe.Pointer(st.users))
+		if st.volatiles != nil {
+			C.free(unsafe.Pointer(st.volatiles))
+		}
 		C.free(unsafe.Pointer(st))
 	}
 }

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -120,9 +120,7 @@ func kuzzle_free_room_options(st *C.room_options) {
 		C.free(unsafe.Pointer(st.scope))
 		C.free(unsafe.Pointer(st.state))
 		C.free(unsafe.Pointer(st.users))
-		if st.volatiles != nil {
-			C.free(unsafe.Pointer(st.volatiles))
-		}
+		C.free(unsafe.Pointer(st.volatiles))
 		C.free(unsafe.Pointer(st))
 	}
 }

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -107,7 +107,7 @@ func SetRoomOptions(options *C.room_options) (opts types.RoomOptions) {
 	if options != nil {
 		opts.SetScope(C.GoString(options.scope))
 		opts.SetState(C.GoString(options.state))
-		opts.SetUsers(C.GoString(options.user))
+		opts.SetUsers(C.GoString(options.users))
 
 		opts.SetSubscribeToSelf(bool(options.subscribe_to_self))
 

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -40,7 +40,7 @@ enum Mode {AUTO, MANUAL};
 #define KUZZLE_ROOM_OPTIONS_DEFAULT { \
     .scope = "all", \
     .state = "all", \
-    .user = "none", \
+    .users = "none", \
     .subscribe_to_self = true, \
     .volatiles = NULL \
 }
@@ -182,7 +182,7 @@ typedef struct {
 typedef struct {
     const char *scope;
     const char *state;
-    const char *user;
+    const char *users;
     bool subscribe_to_self;
     const char *volatiles;
 } room_options;

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -37,6 +37,14 @@ enum Mode {AUTO, MANUAL};
     .refresh = NULL \
 }
 
+#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
+    .scope = "all", \
+    .state = "all", \
+    .user = "none", \
+    .subscribe_to_self = true, \
+    .volatiles = NULL \
+}
+
 enum Event {
     CONNECTED,
     DISCARDED,


### PR DESCRIPTION
## What does this PR do ?

When writing the `relatime:subscribe` documentation for CPP and Java I thought I found a bug because I didn't receive notification when I pass a `room_options` with `scope = "out"`.  
After 2h I finally found why, it was just because when I create a new `room_options` struct, the `subscribe_to_self` option is set to false :upside_down_face: 

This PR add a macro to initialize the `room_options` struct with default values.

### How should this be manually tested?

  - Step 1 : Run a kuzzle stack and create the index `nyc-open-data` and the collection `yellow-taxi`
  - Step 2 : Download this snippet: https://gist.github.com/Aschen/3028d28e5592386fe0cd36a110977b6c
  - Step 3 :  Compile the CPP SDK: `docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all`
 - Step 4 : Copy `kuzzlesdk.h`: `cp sdk-c/include/kuzzlesdk.h include/.`
 - Step 5 : Compile and run the snippet `g++ -std=c++11 realtimesubscribe-documents-leave-scope.cpp -Iinclude -L./build/ -lkuzzlesdk -lpthread -o documentnotification && LD_LIBRARY_PATH=./build ./documentnotification`

### Other changes

 - rename `room_options.user` to `room_options.users` to match the API

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
