### PR TITLE
Add default values for structs

### DIFF
--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -59,8 +59,8 @@ func kuzzle_new_realtime(rt *C.realtime, k *C.kuzzle) {
 }
 
 //export kuzzle_realtime_count
-func kuzzle_realtime_count(rt *C.realtime, index, collection, roomId *C.char, options *C.query_options) *C.int_result {
-	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(index), C.GoString(collection), C.GoString(roomId), SetQueryOptions(options))
+func kuzzle_realtime_count(rt *C.realtime, roomId *C.char, options *C.query_options) *C.int_result {
+	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(roomId), SetQueryOptions(options))
 	return goToCIntResult(res, err)
 }
 

--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -59,8 +59,8 @@ func kuzzle_new_realtime(rt *C.realtime, k *C.kuzzle) {
 }
 
 //export kuzzle_realtime_count
-func kuzzle_realtime_count(rt *C.realtime, roomId *C.char, options *C.query_options) *C.int_result {
-	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(roomId), SetQueryOptions(options))
+func kuzzle_realtime_count(rt *C.realtime, index, collection, roomId *C.char, options *C.query_options) *C.int_result {
+	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(index), C.GoString(collection), C.GoString(roomId), SetQueryOptions(options))
 	return goToCIntResult(res, err)
 }
 

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -24,27 +24,6 @@
 enum Mode {AUTO, MANUAL};
 //options passed to the Kuzzle() fct
 
-#define KUZZLE_OPTIONS_DEFAULT { \
-    .queue_ttl = 120000, \
-    .queue_max_size = 500, \
-    .offline_mode = MANUAL,  \
-    .auto_queue = false,  \
-    .auto_reconnect = true,  \
-    .auto_replay = false, \
-    .auto_resubscribe = true, \
-    .reconnection_delay = 1000, \
-    .replay_interval = 10, \
-    .refresh = NULL \
-}
-
-#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
-    .scope = "all", \
-    .state = "all", \
-    .users = "none", \
-    .subscribe_to_self = true, \
-    .volatiles = NULL \
-}
-
 enum Event {
     CONNECTED,
     DISCARDED,
@@ -179,13 +158,31 @@ typedef struct {
 } subscribe_result;
 
 //options passed to room constructor
-typedef struct {
+typedef struct s_room_options {
     const char *scope;
     const char *state;
     const char *users;
     bool subscribe_to_self;
     const char *volatiles;
+
+  // C++ constructor to have default values
+  # ifdef __cplusplus
+    s_room_options()
+    : scope("all"),
+      state("all"),
+      users("none"),
+      subscribe_to_self(true),
+      volatiles(nullptr) { }
+  # endif
 } room_options;
+
+#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
+    .scope = "all", \
+    .state = "all", \
+    .users = "none", \
+    .subscribe_to_self = true, \
+    .volatiles = NULL \
+}
 
 typedef struct {
     void *instance;
@@ -217,7 +214,7 @@ typedef struct {
     const char *volatiles;
 } query_options;
 
-typedef struct {
+typedef struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
     enum Mode offline_mode;
@@ -228,7 +225,35 @@ typedef struct {
     unsigned long reconnection_delay;
     unsigned long replay_interval;
     const char *refresh;
+
+  // C++ constructor to have default values
+  # ifdef __cplusplus
+    s_options()
+    : queue_ttl(120000),
+      queue_max_size(500),
+      offline_mode(MANUAL),
+      auto_queue(false),
+      auto_reconnect(true),
+      auto_replay(false),
+      auto_resubscribe(true),
+      reconnection_delay(1000),
+      replay_interval(10),
+      refresh(nullptr) {}
+  # endif
 } options;
+
+#define KUZZLE_OPTIONS_DEFAULT { \
+    .queue_ttl = 120000, \
+    .queue_max_size = 500, \
+    .offline_mode = MANUAL,  \
+    .auto_queue = false,  \
+    .auto_reconnect = true,  \
+    .auto_replay = false, \
+    .auto_resubscribe = true, \
+    .reconnection_delay = 1000, \
+    .replay_interval = 10, \
+    .refresh = NULL \
+}
 
 //meta of a document
 typedef struct {


### PR DESCRIPTION
## What does this PR do ?

This PR add default values for `kuzzleio::options` and `kuzzleio::room_options` structs.

### How should this be manually tested?

  - Step 1 : Go to sdk-cpp and put the sdk-c submodule on this branch
  - Step 2 : Make the sdk `docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all`
  - Step 3 :  Get this snippet: https://gist.github.com/Aschen/84b33bf47e883275c690cdaf74c39f98
  - Step 4 :  Compile and run `g++ -std=c++11 source.cpp -Isdk-c/include -Isdk-c/build/ -Iinclude -L./build/ -lkuzzlesdk -lpthread && LD_LIBRARY_PATH=./build ./a.out`
  - Step 5 : You should see `120000` and `'all'` printed to stdout

