### PR TITLE
Remove realtime deprecated methods

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,6 +19,10 @@
   List any dependencies that are required for this change.
 -->
 
+<!-- Uncomment this section to link PR on other SDKs
+:arrow_left: https://github.com/kuzzleio/sdk-go/pull/<id>  :large_blue_circle: https://github.com/kuzzleio/sdk-cpp/pull/<id> :arrow_right:
+-->
+
 ### How should this be manually tested?
 
 <!--

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -20,7 +20,7 @@
 -->
 
 <!-- Uncomment this section to link PR on other SDKs
-:arrow_left: https://github.com/kuzzleio/sdk-go/pull/<id>  :large_blue_circle: https://github.com/kuzzleio/sdk-cpp/pull/<id> :arrow_right:
+https://github.com/kuzzleio/sdk-go/pull/ :arrow_left: :large_blue_circle: :arrow_right: https://github.com/kuzzleio/sdk-cpp/pull/
 -->
 
 ### How should this be manually tested?

--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -64,14 +64,6 @@ func kuzzle_realtime_count(rt *C.realtime, index, collection, roomId *C.char, op
 	return goToCIntResult(res, err)
 }
 
-//export kuzzle_realtime_list
-func kuzzle_realtime_list(rt *C.realtime, index, collection *C.char, options *C.query_options) *C.string_result {
-	res, err := (*realtime.Realtime)(rt.instance).List(C.GoString(index), C.GoString(collection), SetQueryOptions(options))
-	var stringResult string
-	json.Unmarshal(res, &stringResult)
-	return goToCStringResult(&stringResult, err)
-}
-
 //export kuzzle_realtime_publish
 func kuzzle_realtime_publish(rt *C.realtime, index, collection, body *C.char, options *C.query_options) *C.error_result {
 	err := (*realtime.Realtime)(rt.instance).Publish(C.GoString(index), C.GoString(collection), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
@@ -104,10 +96,4 @@ func kuzzle_realtime_subscribe(rt *C.realtime, index, collection, body *C.char, 
 	}()
 
 	return goToCSubscribeResult(subRes, err)
-}
-
-//export kuzzle_realtime_validate
-func kuzzle_realtime_validate(rt *C.realtime, index, collection, body *C.char, options *C.query_options) *C.bool_result {
-	res, err := (*realtime.Realtime)(rt.instance).Validate(C.GoString(index), C.GoString(collection), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
-	return goToCBoolResult(res, err)
 }

--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -59,8 +59,8 @@ func kuzzle_new_realtime(rt *C.realtime, k *C.kuzzle) {
 }
 
 //export kuzzle_realtime_count
-func kuzzle_realtime_count(rt *C.realtime, index, collection, roomId *C.char, options *C.query_options) *C.int_result {
-	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(index), C.GoString(collection), C.GoString(roomId), SetQueryOptions(options))
+func kuzzle_realtime_count(rt *C.realtime, roomId *C.char, options *C.query_options) *C.int_result {
+	res, err := (*realtime.Realtime)(rt.instance).Count(C.GoString(roomId), SetQueryOptions(options))
 	return goToCIntResult(res, err)
 }
 


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?


The following are deprecated and will be removed in Kuzzle v2:
 - `realtime:list` : useless method
 - `realtime:validate` : duplicate with `document:validate`

 https://github.com/kuzzleio/sdk-go/pull/220 :arrow_left: :large_blue_circle: :arrow_right:  https://github.com/kuzzleio/sdk-cpp/pull/17

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 : Make the sdk

### Other change

  - Add optional template to link other sdk PRs