### PR TITLE
Use default value from Go for options and room_options

### DIFF
--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -26,9 +26,20 @@ import (
 	"github.com/kuzzleio/sdk-go/types"
 )
 
-//export kuzzle_new_options
-func kuzzle_new_options() *C.options {
-	copts := (*C.options)(C.calloc(1, C.sizeof_options))
+//export kuzzle_set_default_room_options
+func kuzzle_set_default_room_options(copts *C.room_options) {
+	opts := types.NewRoomOptions()
+
+	copts.scope = C.CString(opts.Scope())
+	copts.state = C.CString(opts.State())
+	copts.users = C.CString(opts.Users())
+	copts.volatiles = C.CString(string(opts.Volatile()))
+	copts.subscribe_to_self = C.bool(opts.SubscribeToSelf())
+	copts.auto_resubscribe = C.bool(opts.AutoResubscribe())
+}
+
+//export kuzzle_set_default_options
+func kuzzle_set_default_options(copts *C.options) {
 	opts := types.NewOptions()
 
 	copts.queue_ttl = C.uint(opts.QueueTTL())
@@ -50,8 +61,6 @@ func kuzzle_new_options() *C.options {
 	if len(refresh) > 0 {
 		copts.refresh = C.CString(refresh)
 	}
-
-	return copts
 }
 
 func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -49,6 +49,14 @@ enum is_action_allowed {
 namespace kuzzleio {
 # endif
 
+// Typedef here to use the type in the function signature
+// function is used to set default value coming from Go to struct
+typedef struct s_options options;
+typedef struct s_room_options room_options;
+
+extern void kuzzle_set_default_options(options*);
+extern void kuzzle_set_default_room_options(room_options*);
+
 //query object used by query()
 typedef struct {
     char *query;
@@ -161,31 +169,22 @@ typedef struct {
 } subscribe_result;
 
 //options passed to room constructor
-typedef struct s_room_options {
+struct s_room_options {
     const char *scope;
     const char *state;
     const char *users;
     bool subscribe_to_self;
+    bool auto_resubscribe;
     const char *volatiles;
 
   // C++ constructor to have default values
   # ifdef __cplusplus
     s_room_options()
-    : scope("all"),
-      state("all"),
-      users("none"),
-      subscribe_to_self(true),
-      volatiles(nullptr) { }
+    {
+      kuzzle_set_default_room_options(this);
+    }
   # endif
-} room_options;
-
-#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
-    .scope = "all", \
-    .state = "all", \
-    .users = "none", \
-    .subscribe_to_self = true, \
-    .volatiles = NULL \
-}
+};
 
 typedef struct {
     void *instance;
@@ -217,7 +216,7 @@ typedef struct {
     const char *volatiles;
 } query_options;
 
-typedef struct s_options {
+struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
     enum Mode offline_mode;
@@ -232,31 +231,11 @@ typedef struct s_options {
   // C++ constructor to have default values
   # ifdef __cplusplus
     s_options()
-    : queue_ttl(120000),
-      queue_max_size(500),
-      offline_mode(MANUAL),
-      auto_queue(false),
-      auto_reconnect(true),
-      auto_replay(false),
-      auto_resubscribe(true),
-      reconnection_delay(1000),
-      replay_interval(10),
-      refresh(nullptr) {}
+    {
+      kuzzle_set_default_options(this);
+    }
   # endif
-} options;
-
-#define KUZZLE_OPTIONS_DEFAULT { \
-    .queue_ttl = 120000, \
-    .queue_max_size = 500, \
-    .offline_mode = MANUAL,  \
-    .auto_queue = false,  \
-    .auto_reconnect = true,  \
-    .auto_replay = false, \
-    .auto_resubscribe = true, \
-    .reconnection_delay = 1000, \
-    .replay_interval = 10, \
-    .refresh = NULL \
-}
+};
 
 //meta of a document
 typedef struct {


### PR DESCRIPTION
## What does this PR do ?

This PR use default value from Go for `options` and `room_options` struct.

(See https://kaliop.slack.com/archives/C0F9LQJFM/p1541440038010100)

### How should this be manually tested?


  - Step 1 : Go to sdk-cpp and put the sdk-c submodule on this branch
  - Step 2 : Make the sdk `docker run --rm -it --network ci_default --link kuzzle -v "$(pwd)":/mnt kuzzleio/sdk-cross:gcc make clean all`
  - Step 3 :  Get this snippet: https://gist.github.com/Aschen/84b33bf47e883275c690cdaf74c39f98
  - Step 4 :  Compile and run `g++ -std=c++11 source.cpp -Isdk-c/include -Isdk-c/build/ -Iinclude -L./build/ -lkuzzlesdk -lpthread && LD_LIBRARY_PATH=./build ./a.out`
  - Step 5 : You should see `120000` and `'all'` printed to stdout
