### PR TITLE
Fix wrapping of options and room_options

### DIFF
--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -35,7 +35,6 @@ func kuzzle_set_default_room_options(copts *C.room_options) {
 	copts.users = C.CString(opts.Users())
 	copts.volatiles = C.CString(string(opts.Volatile()))
 	copts.subscribe_to_self = C.bool(opts.SubscribeToSelf())
-	copts.auto_resubscribe = C.bool(opts.AutoResubscribe())
 }
 
 //export kuzzle_set_default_options

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -26,6 +26,23 @@ import (
 	"github.com/kuzzleio/sdk-go/types"
 )
 
+//export kuzzle_set_default_query_options
+func kuzzle_set_default_query_options(copts *C.query_options) {
+	opts := types.NewQueryOptions()
+
+	copts.queuable = C.bool(opts.Queuable())
+	copts.withdist = C.bool(opts.Withdist())
+	copts.withcoord = C.bool(opts.Withcoord())
+	copts.from = C.long(opts.From())
+	copts.size = C.long(opts.Size())
+	copts.scroll = C.CString(opts.Scroll())
+	copts.scroll_id = C.CString(opts.ScrollId())
+	copts.refresh = C.CString(opts.Refresh())
+	copts.if_exist = C.CString(opts.IfExist())
+	copts.retry_on_conflict = C.int(opts.RetryOnConflict())
+	copts.volatiles = C.CString(string(opts.Volatile()))
+}
+
 //export kuzzle_set_default_room_options
 func kuzzle_set_default_room_options(copts *C.room_options) {
 	opts := types.NewRoomOptions()

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -169,6 +169,7 @@ typedef struct s_room_options {
     const char *volatiles;
 
   // C++ constructor to have default values
+  // TODO use default values from Go
   # ifdef __cplusplus
     s_room_options()
     : scope("all"),
@@ -230,6 +231,7 @@ typedef struct s_options {
     const char *refresh;
 
   // C++ constructor to have default values
+  // TODO use default values from Go
   # ifdef __cplusplus
     s_options()
     : queue_ttl(120000),

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -190,7 +190,7 @@ typedef struct {
 typedef void (callback)(char* notification);
 
 //options passed to query()
-typedef struct {
+typedef struct s_query_options {
     bool queuable;
     bool withdist;
     bool withcoord;
@@ -202,6 +202,11 @@ typedef struct {
     const char *if_exist;
     int retry_on_conflict;
     const char *volatiles;
+
+    // C++ constructor to have default values
+    # ifdef __cplusplus
+      s_query_options();
+    # endif
 } query_options;
 
 typedef struct s_options {

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -161,14 +161,31 @@ typedef struct {
 } subscribe_result;
 
 //options passed to room constructor
-typedef struct {
+typedef struct s_room_options {
     const char *scope;
     const char *state;
     const char *users;
     bool subscribe_to_self;
-    bool auto_resubscribe;
     const char *volatiles;
+
+  // C++ constructor to have default values
+  # ifdef __cplusplus
+    s_room_options()
+    : scope("all"),
+      state("all"),
+      users("none"),
+      subscribe_to_self(true),
+      volatiles(nullptr) { }
+  # endif
 } room_options;
+
+#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
+    .scope = "all", \
+    .state = "all", \
+    .users = "none", \
+    .subscribe_to_self = true, \
+    .volatiles = NULL \
+}
 
 typedef struct {
     void *instance;
@@ -200,7 +217,7 @@ typedef struct {
     const char *volatiles;
 } query_options;
 
-typedef struct {
+typedef struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
     enum Mode offline_mode;
@@ -211,10 +228,37 @@ typedef struct {
     unsigned long reconnection_delay;
     unsigned long replay_interval;
     const char *refresh;
+
+  // C++ constructor to have default values
+  # ifdef __cplusplus
+    s_options()
+    : queue_ttl(120000),
+      queue_max_size(500),
+      offline_mode(MANUAL),
+      auto_queue(false),
+      auto_reconnect(true),
+      auto_replay(false),
+      auto_resubscribe(true),
+      reconnection_delay(1000),
+      replay_interval(10),
+      refresh(nullptr) {}
+  # endif
 } options;
 
-//meta of a document
-typedef struct {
+#define KUZZLE_OPTIONS_DEFAULT { \
+    .queue_ttl = 120000, \
+    .queue_max_size = 500, \
+    .offline_mode = MANUAL,  \
+    .auto_queue = false,  \
+    .auto_reconnect = true,  \
+    .auto_replay = false, \
+    .auto_resubscribe = true, \
+    .reconnection_delay = 1000, \
+    .replay_interval = 10, \
+    .refresh = NULL \
+}
+
+//meta of a documenttypedef struct {
     const char *author;
     unsigned long long created_at;
     unsigned long long updated_at;

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -168,25 +168,11 @@ typedef struct s_room_options {
     bool subscribe_to_self;
     const char *volatiles;
 
-  // C++ constructor to have default values
-  // TODO use default values from Go
-  # ifdef __cplusplus
-    s_room_options()
-    : scope("all"),
-      state("all"),
-      users("none"),
-      subscribe_to_self(true),
-      volatiles(nullptr) { }
-  # endif
+    // C++ constructor to have default values
+    # ifdef __cplusplus
+      s_room_options();
+    # endif
 } room_options;
-
-#define KUZZLE_ROOM_OPTIONS_DEFAULT { \
-    .scope = "all", \
-    .state = "all", \
-    .users = "none", \
-    .subscribe_to_self = true, \
-    .volatiles = NULL \
-}
 
 typedef struct {
     void *instance;
@@ -230,35 +216,11 @@ typedef struct s_options {
     unsigned long replay_interval;
     const char *refresh;
 
-  // C++ constructor to have default values
-  // TODO use default values from Go
-  # ifdef __cplusplus
-    s_options()
-    : queue_ttl(120000),
-      queue_max_size(500),
-      offline_mode(MANUAL),
-      auto_queue(false),
-      auto_reconnect(true),
-      auto_replay(false),
-      auto_resubscribe(true),
-      reconnection_delay(1000),
-      replay_interval(10),
-      refresh(nullptr) {}
-  # endif
+    // C++ constructor to have default values
+    # ifdef __cplusplus
+      s_options();
+    # endif
 } options;
-
-#define KUZZLE_OPTIONS_DEFAULT { \
-    .queue_ttl = 120000, \
-    .queue_max_size = 500, \
-    .offline_mode = MANUAL,  \
-    .auto_queue = false,  \
-    .auto_reconnect = true,  \
-    .auto_replay = false, \
-    .auto_resubscribe = true, \
-    .reconnection_delay = 1000, \
-    .replay_interval = 10, \
-    .refresh = NULL \
-}
 
 //meta of a document
 typedef struct {

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -49,14 +49,6 @@ enum is_action_allowed {
 namespace kuzzleio {
 # endif
 
-// Typedef here to use the type in the function signature
-// function is used to set default value coming from Go to struct
-typedef struct s_options options;
-typedef struct s_room_options room_options;
-
-extern void kuzzle_set_default_options(options*);
-extern void kuzzle_set_default_room_options(room_options*);
-
 //query object used by query()
 typedef struct {
     char *query;
@@ -169,22 +161,14 @@ typedef struct {
 } subscribe_result;
 
 //options passed to room constructor
-struct s_room_options {
+typedef struct {
     const char *scope;
     const char *state;
     const char *users;
     bool subscribe_to_self;
     bool auto_resubscribe;
     const char *volatiles;
-
-  // C++ constructor to have default values
-  # ifdef __cplusplus
-    s_room_options()
-    {
-      kuzzle_set_default_room_options(this);
-    }
-  # endif
-};
+} room_options;
 
 typedef struct {
     void *instance;
@@ -216,7 +200,7 @@ typedef struct {
     const char *volatiles;
 } query_options;
 
-struct s_options {
+typedef struct {
     unsigned queue_ttl;
     unsigned long queue_max_size;
     enum Mode offline_mode;
@@ -227,15 +211,7 @@ struct s_options {
     unsigned long reconnection_delay;
     unsigned long replay_interval;
     const char *refresh;
-
-  // C++ constructor to have default values
-  # ifdef __cplusplus
-    s_options()
-    {
-      kuzzle_set_default_options(this);
-    }
-  # endif
-};
+} options;
 
 //meta of a document
 typedef struct {

--- a/include/kuzzlesdk.h
+++ b/include/kuzzlesdk.h
@@ -260,7 +260,8 @@ typedef struct s_options {
     .refresh = NULL \
 }
 
-//meta of a documenttypedef struct {
+//meta of a document
+typedef struct {
     const char *author;
     unsigned long long created_at;
     unsigned long long updated_at;


### PR DESCRIPTION
## What does this PR do ?

Use default value from Go for `options`, `query_options` and `room_options`. 
:large_blue_circle: :arrow_right: https://github.com/kuzzleio/sdk-cpp/pull/21

### How should this be manually tested?

Test with the CPP and Java sdk only