### PR TITLE
[kzl-832] make document.count body argument optional

### DIFF
--- a/cgo/kuzzle/document.go
+++ b/cgo/kuzzle/document.go
@@ -57,7 +57,11 @@ func kuzzle_new_document(d *C.document, k *C.kuzzle) {
 
 //export kuzzle_document_count
 func kuzzle_document_count(d *C.document, index *C.char, collection *C.char, body *C.char, options *C.query_options) *C.int_result {
-	res, err := (*document.Document)(d.instance).Count(C.GoString(index), C.GoString(collection), json.RawMessage(C.GoString(body)), SetQueryOptions(options))
+	var b json.RawMessage
+	if body != nil {
+		b = json.RawMessage(C.GoString(body))
+	}
+	res, err := (*document.Document)(d.instance).Count(C.GoString(index), C.GoString(collection), b, SetQueryOptions(options))
 	return goToCIntResult(res, err)
 }
 


### PR DESCRIPTION
**:warning: do not merge**
**:warning: depends on https://github.com/kuzzleio/kuzzle/pull/1214**

## What does this PR do?

Following https://github.com/kuzzleio/kuzzle/pull/1214, makes `document.count` `body` property optional.

https://github.com/kuzzleio/sdk-go/pull/225 :arrow_left: :large_blue_circle: :arrow_right: https://github.com/kuzzleio/sdk-cpp/pull/23