### PR TITLE
Fix segfault bis

### DIFF
--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -76,6 +76,8 @@ func kuzzle_set_default_options(copts *C.options) {
 	refresh := opts.Refresh()
 	if len(refresh) > 0 {
 		copts.refresh = C.CString(refresh)
+	} else {
+		copts.refresh = nil
 	}
 }
 


### PR DESCRIPTION

## What does this PR do ?

`options.refresh` was not initialized so it contain garbage sometimes and that cause a segfault.