### PR TITLE
Rename KuzzleNotification and NotificationResult

### DIFF
--- a/cgo/kuzzle/c_to_go.go
+++ b/cgo/kuzzle/c_to_go.go
@@ -255,12 +255,12 @@ func cToGoSearchResult(s *C.search_result) (*types.SearchResult, error) {
 	return sr, nil
 }
 
-func cToGoKuzzleNotificationChannel(c *C.kuzzle_notification_listener) chan<- types.KuzzleNotification {
-	return make(chan<- types.KuzzleNotification)
+func cToGoNotificationResultChannel(c *C.kuzzle_notification_listener) chan<- types.NotificationResult {
+	return make(chan<- types.NotificationResult)
 }
 
 func cToGoQueryObject(cqo *C.query_object, data unsafe.Pointer) *types.QueryObject {
-	notifChan := make(chan *types.KuzzleNotification)
+	notifChan := make(chan *types.NotificationResult)
 	go func() {
 		for {
 			res, ok := <-notifChan

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -71,7 +71,7 @@ func goToCShards(gShards *types.Shards) *C.shards {
 }
 
 // Allocates memory
-func goToCNotificationContent(gNotifContent *types.NotificationResult) *C.notification_content {
+func goToCNotificationContent(gNotifContent *types.NotificationContent) *C.notification_content {
 	result := (*C.notification_content)(C.calloc(1, C.sizeof_notification_content))
 	result.id = C.CString(gNotifContent.Id)
 	result.m = goToCMeta(gNotifContent.Meta)
@@ -83,7 +83,7 @@ func goToCNotificationContent(gNotifContent *types.NotificationResult) *C.notifi
 }
 
 // Allocates memory
-func goToCNotificationResult(gNotif *types.KuzzleNotification) *C.notification_result {
+func goToCNotificationResult(gNotif *types.NotificationResult) *C.notification_result {
 	result := (*C.notification_result)(C.calloc(1, C.sizeof_notification_result))
 
 	if gNotif.Error.Error() != "" {

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -244,7 +244,7 @@ func (wp WrapProtocol) EmitEvent(event int, data interface{}) {
 	C.bridge_emit_event(wp.P.emit_event, C.int(event), nil, wp.P.instance)
 }
 
-func (wp WrapProtocol) RegisterSub(string, string, json.RawMessage, bool, chan<- types.KuzzleNotification, chan<- interface{}) {
+func (wp WrapProtocol) RegisterSub(string, string, json.RawMessage, bool, chan<- types.NotificationResult, chan<- interface{}) {
 	//@todo
 }
 

--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -78,7 +78,7 @@ func kuzzle_realtime_unsubscribe(rt *C.realtime, roomId *C.char, options *C.quer
 
 //export kuzzle_realtime_subscribe
 func kuzzle_realtime_subscribe(rt *C.realtime, index, collection, body *C.char, callback C.kuzzle_notification_listener, data unsafe.Pointer, options *C.room_options) *C.subscribe_result {
-	c := make(chan types.KuzzleNotification)
+	c := make(chan types.NotificationResult)
 	subRes, err := (*realtime.Realtime)(rt.instance).Subscribe(C.GoString(index), C.GoString(collection), json.RawMessage(C.GoString(body)), c, SetRoomOptions(options))
 
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

Rename `KuzzleNotification` to `NotificationResult` and `NotificationResult` to `NotifcicationContent`

### How should this be manually tested?

See travis result.

https://github.com/kuzzleio/sdk-go/pull/228 :arrow_left: