### PR TITLE
Fix non-nil error value returned on success

### DIFF
--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -127,7 +127,7 @@ func kuzzle_websocket_connect(ws *C.web_socket) *C.char {
 	if err != nil {
 		return C.CString(err.Error())
 	}
-	return C.CString("")
+	return nil
 }
 
 //export kuzzle_websocket_send


### PR DESCRIPTION
# Description

The `kuzzle_websocket_connect` CGO method used by the `kuzzle.connect` documented function by all SDK erroneously returns an empty string on success, instead of the expected NULL value.