### PR TITLE
Fix multiple websockets and/or subscriptions conflicts

### DIFF
--- a/cgo/kuzzle/kuzzle.go
+++ b/cgo/kuzzle/kuzzle.go
@@ -37,7 +37,7 @@ import (
 var instances sync.Map
 
 // map which stores channel and function's pointers adresses for listeners
-var listeners_list map[uintptr]chan<- json.RawMessage
+var listeners_list map[uintptr]chan<- json.RawMessage = make(map[uintptr]chan<- json.RawMessage)
 
 // register new instance to the instances map
 func registerKuzzle(instance interface{}, ptr unsafe.Pointer) {
@@ -52,10 +52,6 @@ func unregisterKuzzle(k *C.kuzzle) {
 
 //export kuzzle_new_kuzzle
 func kuzzle_new_kuzzle(k *C.kuzzle, protocol *C.protocol, options *C.options) {
-	if listeners_list == nil {
-		listeners_list = make(map[uintptr]chan<- json.RawMessage)
-	}
-
 	opts := SetOptions(options)
 
 	p := NewWrapProtocol(protocol)

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -157,9 +157,9 @@ type WrapProtocol struct {
 
 var proto_instances sync.Map
 
-var _list_listeners map[int]map[chan<- json.RawMessage]bool
-var _list_once_listeners map[int]map[chan<- json.RawMessage]bool
-var _list_notification_listeners map[string]chan<- types.NotificationResult
+var _list_listeners map[int]map[chan<- json.RawMessage]bool = make(map[int]map[chan<- json.RawMessage]bool)
+var _list_once_listeners map[int]map[chan<- json.RawMessage]bool = make(map[int]map[chan<- json.RawMessage]bool)
+var _list_notification_listeners map[string]chan<- types.NotificationResult = make(map[string]chan<- types.NotificationResult)
 
 // register new instance to the instances map
 func registerProtocol(instance interface{}, ptr unsafe.Pointer) {
@@ -174,9 +174,6 @@ func unregisterProtocol(p *C.protocol) {
 func NewWrapProtocol(p *C.protocol) *WrapProtocol {
 	ptr_proto := unsafe.Pointer(p.instance)
 	registerProtocol(p, ptr_proto)
-	_list_listeners = make(map[int]map[chan<- json.RawMessage]bool)
-	_list_once_listeners = make(map[int]map[chan<- json.RawMessage]bool)
-	_list_notification_listeners = make(map[string]chan<- types.NotificationResult)
 
 	return &WrapProtocol{p}
 }

--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -32,20 +32,19 @@ package main
 import "C"
 import (
 	"encoding/json"
-	"sync"
-	"unsafe"
-
 	"github.com/kuzzleio/sdk-go/protocol/websocket"
 	"github.com/kuzzleio/sdk-go/types"
+	"sync"
+	"unsafe"
 )
 
 // map which stores instances to keep references in case the gc passes
 var webSocketInstances sync.Map
 
 // listeners
-var _event_listeners map[int]map[C.kuzzle_event_listener]chan json.RawMessage
-var _event_once_listeners map[int]map[C.kuzzle_event_listener]chan json.RawMessage
-var _notification_listeners map[string]chan<- types.NotificationResult
+var _event_listeners map[int]map[C.kuzzle_event_listener]chan json.RawMessage = make(map[int]map[C.kuzzle_event_listener]chan json.RawMessage)
+var _event_once_listeners map[int]map[C.kuzzle_event_listener]chan json.RawMessage = make(map[int]map[C.kuzzle_event_listener]chan json.RawMessage)
+var _notification_listeners map[string]chan<- types.NotificationResult = make(map[string]chan<- types.NotificationResult)
 
 // register new instance to the instances map
 func registerWebSocket(instance interface{}, ptr unsafe.Pointer) {
@@ -55,10 +54,6 @@ func registerWebSocket(instance interface{}, ptr unsafe.Pointer) {
 //export kuzzle_websocket_new_web_socket
 func kuzzle_websocket_new_web_socket(ws *C.web_socket, host *C.char, options *C.options, cppInstance unsafe.Pointer) {
 	inst := websocket.NewWebSocket(C.GoString(host), SetOptions(options))
-
-	_event_listeners = make(map[int]map[C.kuzzle_event_listener]chan json.RawMessage)
-	_event_once_listeners = make(map[int]map[C.kuzzle_event_listener]chan json.RawMessage)
-	_notification_listeners = make(map[string]chan<- types.NotificationResult)
 
 	ws.cpp_instance = cppInstance
 	ptr := unsafe.Pointer(inst)


### PR DESCRIPTION
# Description

Some cgo wrappers need to maintain global maps in order to access Go data from non-Go code, namely kuzzle.go, websocket.go and protocol.go

These global maps were initialized in the function creating a new instance for these objects but, in the case of websocket and protocol, there weren't any `if` condition guarding against reinitializing an already instantiated map.

Whenever multiple websocket protocols are instantiated, all accessors from previous instances are lost.

This PR solves this by moving the global maps initialization directly to their declaration, making if-guards useless.