### PR TITLE
Add an enum for the state

### DIFF
--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -67,12 +67,6 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.reconnection_delay = C.ulong(opts.ReconnectionDelay())
 	copts.replay_interval = C.ulong(opts.ReplayInterval())
 
-	if opts.OfflineMode() == 1 {
-		copts.offline_mode = C.MANUAL
-	} else {
-		copts.offline_mode = C.AUTO
-	}
-
 	refresh := opts.Refresh()
 	if len(refresh) > 0 {
 		copts.refresh = C.CString(refresh)
@@ -115,7 +109,6 @@ func SetOptions(options *C.options) (opts types.Options) {
 
 	opts.SetQueueTTL(time.Duration(uint16(options.queue_ttl)))
 	opts.SetQueueMaxSize(int(options.queue_max_size))
-	opts.SetOfflineMode(int(options.offline_mode))
 
 	opts.SetAutoQueue(bool(options.auto_queue))
 	opts.SetAutoReconnect(bool(options.auto_reconnect))

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -21,7 +21,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-enum KuzzleConnectionMode {AUTO, MANUAL};
 //options passed to the Kuzzle() fct
 
 enum KuzzleEvent {
@@ -292,7 +291,6 @@ typedef struct {
 typedef struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
-    enum KuzzleConnectionMode offline_mode;
     bool auto_queue;
     bool auto_reconnect;
     bool auto_replay;

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -21,7 +21,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-enum KuzzleMode {AUTO, MANUAL};
+enum KuzzleConnectionMode {AUTO, MANUAL};
 //options passed to the Kuzzle() fct
 
 enum KuzzleEvent {
@@ -292,7 +292,7 @@ typedef struct {
 typedef struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
-    enum KuzzleMode offline_mode;
+    enum KuzzleConnectionMode offline_mode;
     bool auto_queue;
     bool auto_reconnect;
     bool auto_replay;

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -40,12 +40,9 @@ enum Event {
 
 enum State {
     CONNECTING,
-    DISCONNECTED,
-    CONNECTED,
     INITIALIZING,
     READY,
     LOGGUED_OUT,
-    ERROR,
     OFFLINE
 };
 

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -38,6 +38,17 @@ enum Event {
     ERROR
 };
 
+enum State {
+    CONNECTING
+    DISCONNECTED
+    CONNECTED
+    INITIALIZING
+    READY
+    LOGGUED_OUT
+    ERROR
+    OFFLINE
+};
+
 enum is_action_allowed {
     ALLOWED,
     CONDITIONNAL,

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -49,10 +49,10 @@ enum KuzzleState {
     KUZZLE_STATE_OFFLINE
 };
 
-enum kuzzle_is_action_allowed {
-    KUZZLE_IS_ACTION_ALLOWED,
-    KUZZLE_IS_ACTION_CONDITIONNAL,
-    KUZZLE_IS_ACTION_DENIED
+enum KuzzleAction {
+    KUZZLE_ACTION_ALLOWED,
+    KUZZLE_ACTION_CONDITIONNAL,
+    KUZZLE_ACTION_DENIED
 };
 
 

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -39,13 +39,13 @@ enum Event {
 };
 
 enum State {
-    CONNECTING
-    DISCONNECTED
-    CONNECTED
-    INITIALIZING
-    READY
-    LOGGUED_OUT
-    ERROR
+    CONNECTING,
+    DISCONNECTED,
+    CONNECTED,
+    INITIALIZING,
+    READY,
+    LOGGUED_OUT,
+    ERROR,
     OFFLINE
 };
 

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef _KUZZLESDK_H_
-#define _KUZZLESDK_H_
+#ifndef _KUZZLE_STRUCTS_H_
+#define _KUZZLE_STRUCTS_H_
 
 #include <time.h>
 #include <errno.h>
@@ -21,35 +21,38 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-enum Mode {AUTO, MANUAL};
+enum KuzzleMode {AUTO, MANUAL};
 //options passed to the Kuzzle() fct
 
-enum Event {
-    CONNECTED,
-    DISCARDED,
-    DISCONNECTED,
-    LOGIN_ATTEMPT,
-    NETWORK_ERROR,
-    OFFLINE_QUEUE_POP,
-    OFFLINE_QUEUE_PUSH,
-    QUERY_ERROR,
-    RECONNECTED,
-    JWT_EXPIRED,
-    ERROR
+enum KuzzleEvent {
+    KUZZLE_EVENT_CONNECTED,
+    KUZZLE_EVENT_DISCARDED,
+    KUZZLE_EVENT_DISCONNECTED,
+    KUZZLE_EVENT_LOGIN_ATTEMPT,
+    KUZZLE_EVENT_NETWORK_ERROR,
+    KUZZLE_EVENT_OFFLINE_QUEUE_POP,
+    KUZZLE_EVENT_OFFLINE_QUEUE_PUSH,
+    KUZZLE_EVENT_QUERY_ERROR,
+    KUZZLE_EVENT_RECONNECTED,
+    KUZZLE_EVENT_JWT_EXPIRED,
+    KUZZLE_EVENT_ERROR
 };
 
-enum State {
-    CONNECTING,
-    INITIALIZING,
-    READY,
-    LOGGUED_OUT,
-    OFFLINE
+enum KuzzleState {
+    KUZZLE_STATE_CONNECTING,
+    KUZZLE_STATE_DISCONNECTED,
+    KUZZLE_STATE_CONNECTED,
+    KUZZLE_STATE_INITIALIZING,
+    KUZZLE_STATE_READY,
+    KUZZLE_STATE_LOGGUED_OUT,
+    KUZZLE_STATE_ERROR,
+    KUZZLE_STATE_OFFLINE
 };
 
-enum is_action_allowed {
-    ALLOWED,
-    CONDITIONNAL,
-    DENIED
+enum kuzzle_is_action_allowed {
+    KUZZLE_IS_ACTION_ALLOWED,
+    KUZZLE_IS_ACTION_CONDITIONNAL,
+    KUZZLE_IS_ACTION_DENIED
 };
 
 
@@ -289,7 +292,7 @@ typedef struct {
 typedef struct s_options {
     unsigned queue_ttl;
     unsigned long queue_max_size;
-    enum Mode offline_mode;
+    enum KuzzleMode offline_mode;
     bool auto_queue;
     bool auto_reconnect;
     bool auto_replay;


### PR DESCRIPTION
## What does this PR do ?

Add the `State` enum containing those values:

```
    KUZZLE_STATE_CONNECTING,
    KUZZLE_STATE_DISCONNECTED,
    KUZZLE_STATE_CONNECTED,
    KUZZLE_STATE_INITIALIZING,
    KUZZLE_STATE_READY,
    KUZZLE_STATE_LOGGUED_OUT,
    KUZZLE_STATE_ERROR,
    KUZZLE_STATE_OFFLINE
```

## Other changes

Renamed enum.

:arrow_right:  https://github.com/kuzzleio/sdk-cpp/pull/43
