### PR TITLE
Fix struct destructors

### DIFF
--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -366,7 +366,7 @@ func kuzzle_free_user_right(st *C.user_right) {
 func kuzzle_free_user_rights_result(st *C.user_rights_result) {
 	if st != nil {
 		if st.rights != nil {
-			rights := (*[1<<27 - 1]C.user_right)(unsafe.Pointer(st.rights))[:int(st.rights_length):int(st.rights_length)]
+			rights := (*[1<<26 - 1]C.user_right)(unsafe.Pointer(st.rights))[:int(st.rights_length):int(st.rights_length)]
 
 			for _, right := range rights {
 				_free_user_right(&right)

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -504,6 +504,15 @@ func kuzzle_free_int_result(st *C.int_result) {
 	}
 }
 
+//export kuzzle_free_date_result
+func kuzzle_free_date_result(st *C.date_result) {
+	if st != nil {
+		C.free(unsafe.Pointer(st.error))
+		C.free(unsafe.Pointer(st.stack))
+		C.free(unsafe.Pointer(st))
+	}
+}
+
 //export kuzzle_free_double_result
 func kuzzle_free_double_result(st *C.double_result) {
 	if st != nil {

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -365,9 +365,18 @@ func kuzzle_free_user_right(st *C.user_right) {
 //export kuzzle_free_user_rights_result
 func kuzzle_free_user_rights_result(st *C.user_rights_result) {
 	if st != nil {
+		if st.rights != nil {
+			rights := (*[1<<27 - 1]C.user_right)(unsafe.Pointer(st.rights))[:int(st.rights_length):int(st.rights_length)]
+
+			for _, right := range rights {
+				_free_user_right(&right)
+			}
+
+			C.free(unsafe.Pointer(st.rights))
+		}
+
 		C.free(unsafe.Pointer(st.error))
 		C.free(unsafe.Pointer(st.stack))
-		C.free(unsafe.Pointer(st.result))
 		C.free(unsafe.Pointer(st))
 	}
 }

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -782,16 +782,14 @@ func goToCUserRightsResult(rights []*types.UserRights, err error) *C.user_rights
 	}
 
 	if rights != nil {
-		resultsSize := len(rights) + 1
+		result.rights_length = C.size_t(len(rights))
 
-		result.result = (**C.user_right)(C.calloc(C.size_t(resultsSize), C.sizeof_user_right))
-		carray := (*[1<<28 - 1]*C.user_right)(unsafe.Pointer(result.result))[:resultsSize:resultsSize]
+		result.rights = (**C.user_right)(C.calloc(C.size_t(len(rights)), C.sizeof_user_right))
+		carray := (*[1<<28 - 1]*C.user_right)(unsafe.Pointer(result.rights))[:len(rights):len(rights)]
 
 		for i, right := range rights {
 			carray[i] = goToCUserRight(right)
 		}
-
-		carray[resultsSize-1] = nil
 	}
 
 	return result

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -398,7 +398,8 @@ typedef struct {
 } user_right;
 
 typedef struct user_rights_result {
-  user_right **result;
+  user_right **rights;
+  size_t rights_length;
   int status;
   const char *error;
   const char *stack;


### PR DESCRIPTION
# Description

* Add missing destructor for the `date_result` struct
* Fix how the user_rights struct is handled:
  * Convert the user_rights underlying results from a NULL-terminated array to a size-delimited one
  * Rename the user_rights result property from "result" to "rights", and add a "rights_length" properties, making it on par with every other structs
  * Fix the destructor which was not freeing the memory correctly