### PR TITLE
Keep enums without prefix in C++

### DIFF
--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -57,6 +57,11 @@ enum KuzzleAction {
 
 # ifdef __cplusplus
 namespace kuzzleio {
+
+  typedef KuzzleEvent Event;
+  typedef KuzzleState State;
+  typedef KuzzleAction Action;
+
 # endif
 
 //meta of a document


### PR DESCRIPTION
## What does this PR do ?

Keep enums without prefix in the namespace for C++
