### PR TITLE
[websocket] allow passing HTTP headers to the ws ctor

### DIFF
--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -129,6 +129,12 @@ func kuzzle_free_room_options(st *C.room_options) {
 func kuzzle_free_options(st *C.options) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.refresh))
+
+		if st.header_size > 0 {
+			C.free_char_array(st.header_names, st.header_size)
+			C.free_char_array(st.header_values, st.header_size)
+		}
+
 		C.free(unsafe.Pointer(st))
 	}
 }

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -67,6 +67,9 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.auto_resubscribe = C.bool(opts.AutoResubscribe())
 	copts.reconnection_delay = C.ulong(opts.ReconnectionDelay())
 	copts.replay_interval = C.ulong(opts.ReplayInterval())
+	copts.header_size = C.size_t(0)
+	copts.header_names = nil
+	copts.header_values = nil
 
 	refresh := opts.Refresh()
 	if len(refresh) > 0 {

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -59,6 +59,7 @@ func kuzzle_set_default_room_options(copts *C.room_options) {
 func kuzzle_set_default_options(copts *C.options) {
 	opts := types.NewOptions()
 
+	copts.port = C.uint(opts.Port())
 	copts.queue_ttl = C.uint(opts.QueueTTL())
 	copts.queue_max_size = C.ulong(opts.QueueMaxSize())
 	copts.auto_queue = C.bool(opts.AutoQueue())
@@ -111,6 +112,7 @@ func SetOptions(options *C.options) (opts types.Options) {
 
 	opts = types.NewOptions()
 
+	opts.SetPort(int(options.port))
 	opts.SetQueueTTL(time.Duration(uint16(options.queue_ttl)))
 	opts.SetQueueMaxSize(int(options.queue_max_size))
 

--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -52,9 +52,7 @@ func registerWebSocket(instance interface{}, ptr unsafe.Pointer) {
 }
 
 //export kuzzle_websocket_new_web_socket
-func kuzzle_websocket_new_web_socket(ws *C.web_socket, host *C.char,
-	options *C.options, cppInstance unsafe.Pointer) {
-
+func kuzzle_websocket_new_web_socket(ws *C.web_socket, host *C.char, options *C.options, cppInstance unsafe.Pointer) {
 	inst := websocket.NewWebSocket(C.GoString(host), SetOptions(options))
 
 	ws.cpp_instance = cppInstance

--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -52,7 +52,9 @@ func registerWebSocket(instance interface{}, ptr unsafe.Pointer) {
 }
 
 //export kuzzle_websocket_new_web_socket
-func kuzzle_websocket_new_web_socket(ws *C.web_socket, host *C.char, options *C.options, cppInstance unsafe.Pointer) {
+func kuzzle_websocket_new_web_socket(ws *C.web_socket, host *C.char,
+	options *C.options, cppInstance unsafe.Pointer) {
+
 	inst := websocket.NewWebSocket(C.GoString(host), SetOptions(options))
 
 	ws.cpp_instance = cppInstance

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -294,6 +294,7 @@ typedef struct {
 } subscribe_result;
 
 typedef struct s_options {
+    unsigned int port;
     unsigned queue_ttl;
     unsigned long queue_max_size;
     bool auto_queue;

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -306,8 +306,8 @@ typedef struct s_options {
     const char *refresh;
 
     // HTTP headers
-    const char * const * header_names;
-    const char * const * header_values;
+    char ** header_names;
+    char ** header_values;
     size_t header_size;
 
     // C++ constructor to have default values

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -304,6 +304,11 @@ typedef struct s_options {
     unsigned long replay_interval;
     const char *refresh;
 
+    // HTTP headers
+    const char * const * header_names;
+    const char * const * header_values;
+    size_t header_size;
+
     // C++ constructor to have default values
     # ifdef __cplusplus
       s_options();


### PR DESCRIPTION
:warning: depends on https://github.com/kuzzleio/sdk-go/pull/233

# Description

Allow users to pass HTTP headers to new WebSocket instances.

To pass HTTP headers, simply fill the appropriate properties in the `options` struct:

```c
const char * const * header_names;  // Header names
const char * const * header_values; // Header values
size_t header_size;                 // Number of headers
```

# Other change

* add the missing `port` option for protocols