### PR TITLE
Fix the HTTP header length property name

### DIFF
--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -130,9 +130,9 @@ func kuzzle_free_options(st *C.options) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.refresh))
 
-		if st.header_size > 0 {
-			C.free_char_array(st.header_names, st.header_size)
-			C.free_char_array(st.header_values, st.header_size)
+		if st.header_length > 0 {
+			C.free_char_array(st.header_names, st.header_length)
+			C.free_char_array(st.header_values, st.header_length)
 		}
 
 		C.free(unsafe.Pointer(st))

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -68,7 +68,7 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.auto_resubscribe = C.bool(opts.AutoResubscribe())
 	copts.reconnection_delay = C.ulong(opts.ReconnectionDelay())
 	copts.replay_interval = C.ulong(opts.ReplayInterval())
-	copts.header_size = C.size_t(0)
+	copts.header_length = C.size_t(0)
 	copts.header_names = nil
 	copts.header_values = nil
 
@@ -126,13 +126,13 @@ func SetOptions(options *C.options) (opts types.Options) {
 		opts.SetRefresh(C.GoString(options.refresh))
 	}
 
-	if options.header_size > 0 {
+	if options.header_length > 0 {
 		httpHeaders := &http.Header{}
 
-		hnames := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_names))[:options.header_size:options.header_size]
-		hvals := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_values))[:options.header_size:options.header_size]
+		hnames := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_names))[:options.header_length:options.header_length]
+		hvals := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_values))[:options.header_length:options.header_length]
 
-		for i := 0; i < int(options.header_size); i++ {
+		for i := 0; i < int(options.header_length); i++ {
 			httpHeaders.Add(
 				C.GoString(hnames[i]),
 				C.GoString(hvals[i]))

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -308,7 +308,7 @@ typedef struct s_options {
     // HTTP headers
     char ** header_names;
     char ** header_values;
-    size_t header_size;
+    size_t header_length;
 
     // C++ constructor to have default values
     # ifdef __cplusplus


### PR DESCRIPTION
# Description

In the `options` struct, the property used to keep track of the number of HTTP headers has been incorrectly named `header_size` instead of `header_length`, like all other similar properties.
