### PR TITLE
options: remove "refresh" and the C++ default ctor

### DIFF
--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -128,8 +128,6 @@ func kuzzle_free_room_options(st *C.room_options) {
 //export kuzzle_free_options
 func kuzzle_free_options(st *C.options) {
 	if st != nil {
-		C.free(unsafe.Pointer(st.refresh))
-
 		if st.header_length > 0 {
 			C.free_char_array(st.header_names, st.header_length)
 			C.free_char_array(st.header_values, st.header_length)

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -130,9 +130,9 @@ func kuzzle_free_options(st *C.options) {
 	if st != nil {
 		C.free(unsafe.Pointer(st.refresh))
 
-		if st.header_size > 0 {
-			C.free_char_array(st.header_names, st.header_size)
-			C.free_char_array(st.header_values, st.header_size)
+		if st.header_length > 0 {
+			C.free_char_array(st.header_names, st.header_length)
+			C.free_char_array(st.header_values, st.header_length)
 		}
 
 		C.free(unsafe.Pointer(st))

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -71,13 +71,6 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.header_length = C.size_t(0)
 	copts.header_names = nil
 	copts.header_values = nil
-
-	refresh := opts.Refresh()
-	if len(refresh) > 0 {
-		copts.refresh = C.CString(refresh)
-	} else {
-		copts.refresh = nil
-	}
 }
 
 func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {
@@ -122,9 +115,6 @@ func SetOptions(options *C.options) (opts types.Options) {
 	opts.SetAutoResubscribe(bool(options.auto_resubscribe))
 	opts.SetReconnectionDelay(time.Duration(int(options.reconnection_delay)))
 	opts.SetReplayInterval(time.Duration(int(options.replay_interval)))
-	if options.refresh != nil {
-		opts.SetRefresh(C.GoString(options.refresh))
-	}
 
 	if options.header_length > 0 {
 		httpHeaders := &http.Header{}

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -68,7 +68,7 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.auto_resubscribe = C.bool(opts.AutoResubscribe())
 	copts.reconnection_delay = C.ulong(opts.ReconnectionDelay())
 	copts.replay_interval = C.ulong(opts.ReplayInterval())
-	copts.header_size = C.size_t(0)
+	copts.header_length = C.size_t(0)
 	copts.header_names = nil
 	copts.header_values = nil
 
@@ -126,13 +126,13 @@ func SetOptions(options *C.options) (opts types.Options) {
 		opts.SetRefresh(C.GoString(options.refresh))
 	}
 
-	if options.header_size > 0 {
+	if options.header_length > 0 {
 		httpHeaders := &http.Header{}
 
-		hnames := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_names))[:options.header_size:options.header_size]
-		hvals := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_values))[:options.header_size:options.header_size]
+		hnames := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_names))[:options.header_length:options.header_length]
+		hvals := (*[1<<28 - 1]*C.char)(unsafe.Pointer(options.header_values))[:options.header_length:options.header_length]
 
-		for i := 0; i < int(options.header_size); i++ {
+		for i := 0; i < int(options.header_length); i++ {
 			httpHeaders.Add(
 				C.GoString(hnames[i]),
 				C.GoString(hvals[i]))

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -308,7 +308,7 @@ typedef struct s_options {
     // HTTP headers
     char ** header_names;
     char ** header_values;
-    size_t header_size;
+    size_t header_length;
 
     // C++ constructor to have default values
     # ifdef __cplusplus

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -303,17 +303,11 @@ typedef struct s_options {
     bool auto_resubscribe;
     unsigned long reconnection_delay;
     unsigned long replay_interval;
-    const char *refresh;
 
     // HTTP headers
     char ** header_names;
     char ** header_values;
     size_t header_length;
-
-    // C++ constructor to have default values
-    # ifdef __cplusplus
-      s_options();
-    # endif
 } options;
 
 /* === Security === */


### PR DESCRIPTION
:warning: depends on #50 
:warning: depends on https://github.com/kuzzleio/sdk-go/pull/235

# Description

* `refresh` is not a valid Kuzzle or Protocol option
* remove the C++ default constructor, for a better separation of concern. A new options wrapper will be added to the C++ SDK