### PR TITLE
Add missing ssl_connection in the options struct

### DIFF
--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -72,13 +72,6 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.header_names = nil
 	copts.header_values = nil
 	copts.ssl_connection = false
-
-	refresh := opts.Refresh()
-	if len(refresh) > 0 {
-		copts.refresh = C.CString(refresh)
-	} else {
-		copts.refresh = nil
-	}
 }
 
 func SetQueryOptions(options *C.query_options) (opts types.QueryOptions) {

--- a/cgo/kuzzle/options.go
+++ b/cgo/kuzzle/options.go
@@ -71,6 +71,7 @@ func kuzzle_set_default_options(copts *C.options) {
 	copts.header_length = C.size_t(0)
 	copts.header_names = nil
 	copts.header_values = nil
+	copts.ssl_connection = false
 
 	refresh := opts.Refresh()
 	if len(refresh) > 0 {
@@ -113,6 +114,7 @@ func SetOptions(options *C.options) (opts types.Options) {
 	opts = types.NewOptions()
 
 	opts.SetPort(int(options.port))
+	opts.SetSslConnection(bool(options.ssl_connection))
 	opts.SetQueueTTL(time.Duration(uint16(options.queue_ttl)))
 	opts.SetQueueMaxSize(int(options.queue_max_size))
 

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -304,6 +304,7 @@ typedef struct s_options {
     unsigned long reconnection_delay;
     unsigned long replay_interval;
     const char *refresh;
+    bool ssl_connection;
 
     // HTTP headers
     char ** header_names;

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -303,7 +303,6 @@ typedef struct s_options {
     bool auto_resubscribe;
     unsigned long reconnection_delay;
     unsigned long replay_interval;
-    const char *refresh;
     bool ssl_connection;
 
     // HTTP headers


### PR DESCRIPTION
## What does this PR do ?

Add the missing `ssl_connection` boolean inside the `options` struct and add it in the `SetOptions` function in `cgo`