### PR TITLE
Stability fixes - first pass

### DIFF
--- a/cgo/kuzzle/c_to_go.go
+++ b/cgo/kuzzle/c_to_go.go
@@ -140,7 +140,7 @@ func cToGoUser(u *C.kuzzle_user) *security.User {
 	return user
 }
 
-func cToGoUserRigh(r *C.user_right) *types.UserRights {
+func cToGoUserRight(r *C.user_right) *types.UserRights {
 	right := &types.UserRights{
 		Controller: C.GoString(r.controller),
 		Action:     C.GoString(r.action),
@@ -242,12 +242,17 @@ func cToGoSearchResult(s *C.search_result) (*types.SearchResult, error) {
 	options.SetScroll(C.GoString(s.options.scroll))
 	options.SetScrollId(C.GoString(s.options.scroll_id))
 
-	kuzzle := (*kuzzle.Kuzzle)(s.k.instance)
 	scrollAction := C.GoString(s.scroll_action)
 	request := cToGoKuzzleRequest(s.request)
 	response := cToGoKuzzleResponse(s.response)
 
-	sr, err := types.NewSearchResult(kuzzle, scrollAction, request, options, response)
+	sr, err := types.NewSearchResult(
+		(*kuzzle.Kuzzle)(s.k.instance),
+		scrollAction,
+		request,
+		options,
+		response)
+
 	if err != nil {
 		return nil, err
 	}
@@ -298,9 +303,9 @@ func cToGoQueryObject(cqo *C.query_object, data unsafe.Pointer) *types.QueryObje
 
 func CToGoNotificationContent(cnc *C.notification_content) *types.NotificationContent {
 	notifContent := types.NotificationContent{
-		Id: C.GoString(cnc.id),
+		Id:      C.GoString(cnc.id),
 		Content: json.RawMessage(C.GoString(cnc.content)),
-		Count: int(cnc.count),
+		Count:   int(cnc.count),
 	}
 
 	if cnc.m != nil {
@@ -312,20 +317,20 @@ func CToGoNotificationContent(cnc *C.notification_content) *types.NotificationCo
 
 func cToGoNotificationResult(cnr *C.notification_result) *types.NotificationResult {
 	notifResult := types.NotificationResult{
-		RequestId: C.GoString(cnr.request_id),
-		Result: CToGoNotificationContent(cnr.result),
-		Volatile: json.RawMessage(C.GoString(cnr.volatiles)),
-		Index: C.GoString(cnr.index),
+		RequestId:  C.GoString(cnr.request_id),
+		Result:     CToGoNotificationContent(cnr.result),
+		Volatile:   json.RawMessage(C.GoString(cnr.volatiles)),
+		Index:      C.GoString(cnr.index),
 		Collection: C.GoString(cnr.collection),
 		Controller: C.GoString(cnr.controller),
-		Action: C.GoString(cnr.action),
-		Protocol: C.GoString(cnr.protocol),
-		Scope: C.GoString(cnr.scope),
-		State: C.GoString(cnr.state),
-		User: C.GoString(cnr.user),
-		Type: C.GoString(cnr.n_type),
-		RoomId: C.GoString(cnr.room_id),
-		Timestamp: int(cnr.timestamp),
+		Action:     C.GoString(cnr.action),
+		Protocol:   C.GoString(cnr.protocol),
+		Scope:      C.GoString(cnr.scope),
+		State:      C.GoString(cnr.state),
+		User:       C.GoString(cnr.user),
+		Type:       C.GoString(cnr.n_type),
+		RoomId:     C.GoString(cnr.room_id),
+		Timestamp:  int(cnr.timestamp),
 	}
 
 	if cnr.error != nil {

--- a/cgo/kuzzle/collection.go
+++ b/cgo/kuzzle/collection.go
@@ -22,12 +22,10 @@ package main
 import "C"
 import (
 	"encoding/json"
-	"sync"
-	"unsafe"
-
 	"github.com/kuzzleio/sdk-go/collection"
 	"github.com/kuzzleio/sdk-go/kuzzle"
-	"github.com/kuzzleio/sdk-go/types"
+	"sync"
+	"unsafe"
 )
 
 // map which stores instances to keep references in case the gc passes
@@ -127,7 +125,9 @@ func kuzzle_collection_search_specifications(c *C.collection, body *C.char, opti
 
 //export kuzzle_collection_search_specifications_next
 func kuzzle_collection_search_specifications_next(sr *C.search_result) *C.search_result {
-	res, err := (*types.SearchResult)(sr.instance).Next()
+	goSearchResult, _ := cToGoSearchResult(sr)
+
+	res, err := goSearchResult.Next()
 	return goToCSearchResult(sr.k, res, err)
 }
 

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -645,11 +645,9 @@ func kuzzle_free_specification_result(st *C.specification_result) {
 //export kuzzle_free_search_result
 func kuzzle_free_search_result(sr *C.search_result) {
 	if sr != nil {
-		C.free(unsafe.Pointer(sr.instance))
 		C.free(unsafe.Pointer(sr.aggregations))
 		C.free(unsafe.Pointer(sr.hits))
 		C.free(unsafe.Pointer(sr.scroll_id))
-		C.free(unsafe.Pointer(sr.k))
 		kuzzle_free_kuzzle_request(sr.request)
 		kuzzle_free_kuzzle_response(sr.response)
 		kuzzle_free_query_options(sr.options)
@@ -664,11 +662,9 @@ func kuzzle_free_search_result(sr *C.search_result) {
 //export kuzzle_free_search_profiles_result
 func kuzzle_free_search_profiles_result(sr *C.search_profiles_result) {
 	if sr != nil {
-		C.free(unsafe.Pointer(sr.instance))
 		C.free(unsafe.Pointer(sr.aggregations))
 		C.free(unsafe.Pointer(sr.hits))
 		C.free(unsafe.Pointer(sr.scroll_id))
-		C.free(unsafe.Pointer(sr.k))
 		kuzzle_free_kuzzle_request(sr.request)
 		kuzzle_free_kuzzle_response(sr.response)
 		kuzzle_free_query_options(sr.options)
@@ -683,11 +679,9 @@ func kuzzle_free_search_profiles_result(sr *C.search_profiles_result) {
 //export kuzzle_free_search_roles_result
 func kuzzle_free_search_roles_result(sr *C.search_roles_result) {
 	if sr != nil {
-		C.free(unsafe.Pointer(sr.instance))
 		C.free(unsafe.Pointer(sr.aggregations))
 		C.free(unsafe.Pointer(sr.hits))
 		C.free(unsafe.Pointer(sr.scroll_id))
-		C.free(unsafe.Pointer(sr.k))
 		kuzzle_free_kuzzle_request(sr.request)
 		kuzzle_free_kuzzle_response(sr.response)
 		kuzzle_free_query_options(sr.options)
@@ -788,11 +782,9 @@ func kuzzle_free_user_search(st *C.user_search) {
 //export kuzzle_free_search_users_result
 func kuzzle_free_search_users_result(sr *C.search_users_result) {
 	if sr != nil {
-		C.free(unsafe.Pointer(sr.instance))
 		C.free(unsafe.Pointer(sr.aggregations))
 		C.free(unsafe.Pointer(sr.hits))
 		C.free(unsafe.Pointer(sr.scroll_id))
-		C.free(unsafe.Pointer(sr.k))
 		kuzzle_free_kuzzle_request(sr.request)
 		kuzzle_free_kuzzle_response(sr.response)
 		kuzzle_free_query_options(sr.options)

--- a/cgo/kuzzle/destructors.go
+++ b/cgo/kuzzle/destructors.go
@@ -384,6 +384,7 @@ func kuzzle_free_user_rights_result(st *C.user_rights_result) {
 //export kuzzle_free_user_result
 func kuzzle_free_user_result(st *C.user_result) {
 	if st != nil {
+		kuzzle_free_user(st.result)
 		C.free(unsafe.Pointer(st.error))
 		C.free(unsafe.Pointer(st.stack))
 		C.free(unsafe.Pointer(st))

--- a/cgo/kuzzle/document.go
+++ b/cgo/kuzzle/document.go
@@ -22,12 +22,11 @@ package main
 import "C"
 import (
 	"encoding/json"
-	"sync"
-	"unsafe"
-
+	"fmt"
 	"github.com/kuzzleio/sdk-go/document"
 	"github.com/kuzzleio/sdk-go/kuzzle"
-	"github.com/kuzzleio/sdk-go/types"
+	"sync"
+	"unsafe"
 )
 
 // map which stores instances to keep references in case the gc passes
@@ -45,13 +44,12 @@ func unregisterDocument(d *C.document) {
 }
 
 //export kuzzle_new_document
-func kuzzle_new_document(d *C.document, k *C.kuzzle) {
-	kuz := (*kuzzle.Kuzzle)(k.instance)
+func kuzzle_new_document(d *C.document) {
+	kuz := (*kuzzle.Kuzzle)(d.k.instance)
 	doc := document.NewDocument(kuz)
 
 	ptr := unsafe.Pointer(doc)
 	d.instance = ptr
-	d.k = k
 	registerDocument(doc, ptr)
 }
 
@@ -132,7 +130,12 @@ func kuzzle_document_search(d *C.document, index *C.char, collection *C.char, bo
 
 //export kuzzle_document_search_next
 func kuzzle_document_search_next(sr *C.search_result) *C.search_result {
-	res, err := (*types.SearchResult)(sr.instance).Next()
+	goSearchResult, _ := cToGoSearchResult(sr)
+
+	res, err := goSearchResult.Next()
+	if res == nil {
+		fmt.Println("res is null :-(")
+	}
 	return goToCSearchResult(sr.k, res, err)
 }
 

--- a/cgo/kuzzle/document.go
+++ b/cgo/kuzzle/document.go
@@ -22,7 +22,6 @@ package main
 import "C"
 import (
 	"encoding/json"
-	"fmt"
 	"github.com/kuzzleio/sdk-go/document"
 	"github.com/kuzzleio/sdk-go/kuzzle"
 	"sync"

--- a/cgo/kuzzle/document.go
+++ b/cgo/kuzzle/document.go
@@ -131,11 +131,7 @@ func kuzzle_document_search(d *C.document, index *C.char, collection *C.char, bo
 //export kuzzle_document_search_next
 func kuzzle_document_search_next(sr *C.search_result) *C.search_result {
 	goSearchResult, _ := cToGoSearchResult(sr)
-
 	res, err := goSearchResult.Next()
-	if res == nil {
-		fmt.Println("res is null :-(")
-	}
 	return goToCSearchResult(sr.k, res, err)
 }
 

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -108,8 +108,7 @@ func goToCNotificationResult(
 	result.room_id = C.CString(gNotif.RoomId)
 	result.timestamp = C.ulonglong(gNotif.Timestamp)
 	result.status = C.int(gNotif.Status)
-	fmt.Println("=== converted notification to C struct")
-	fmt.Printf("===> %s\n", gNotif.Result.Content)
+
 	return result
 }
 
@@ -555,7 +554,7 @@ func goToCSearchResult(k *C.kuzzle, sr *types.SearchResult, err error) *C.search
 	result.response = goToCKuzzleResponse(sr.Response())
 	result.options = goToCQueryOptions(sr.Options())
 	result.scroll_action = C.CString(sr.ScrollAction())
-	fmt.Printf("result.fetched = %d\n", result.fetched)
+
 	return result
 }
 

--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -83,7 +83,9 @@ func goToCNotificationContent(gNotifContent *types.NotificationContent) *C.notif
 }
 
 // Allocates memory
-func goToCNotificationResult(gNotif *types.NotificationResult) *C.notification_result {
+func goToCNotificationResult(
+	gNotif *types.NotificationResult) *C.notification_result {
+
 	result := (*C.notification_result)(C.calloc(1, C.sizeof_notification_result))
 
 	if gNotif.Error.Error() != "" {
@@ -106,7 +108,8 @@ func goToCNotificationResult(gNotif *types.NotificationResult) *C.notification_r
 	result.room_id = C.CString(gNotif.RoomId)
 	result.timestamp = C.ulonglong(gNotif.Timestamp)
 	result.status = C.int(gNotif.Status)
-
+	fmt.Println("=== converted notification to C struct")
+	fmt.Printf("===> %s\n", gNotif.Result.Content)
 	return result
 }
 
@@ -276,7 +279,9 @@ func goToCStringResult(goRes *string, err error) *C.string_result {
 	return result
 }
 
-func goToCSubscribeResult(goRes *types.SubscribeResult, err error) *C.subscribe_result {
+func goToCSubscribeResult(goRes *types.SubscribeResult,
+	err error) *C.subscribe_result {
+
 	result := (*C.subscribe_result)(C.calloc(1, C.sizeof_subscribe_result))
 
 	if err != nil {
@@ -410,7 +415,16 @@ func goToCProfile(k *C.kuzzle, profile *security.Profile, dest *C.profile) *C.pr
 }
 
 func goToCProfileSearchResult(k *C.kuzzle, sr *security.ProfileSearchResult, err error) *C.search_profiles_result {
-	result := (*C.search_profiles_result)(C.calloc(1, C.sizeof_search_profiles_result))
+	// this situation arises when a next() is performed on the last
+	// search result page
+	if sr == nil && err == nil {
+		return nil
+	}
+
+	result := (*C.search_profiles_result)(C.calloc(
+		1,
+		C.sizeof_search_profiles_result))
+	result.k = k
 
 	if err != nil {
 		Set_search_profiles_result_error(result, err)
@@ -432,7 +446,7 @@ func goToCProfileSearchResult(k *C.kuzzle, sr *security.ProfileSearchResult, err
 	result.scroll_id = C.CString(sr.ScrollId)
 
 	result.instance = unsafe.Pointer(sr)
-	result.k = k
+
 	result.request = goToCKuzzleRequest(sr.Request())
 	result.response = goToCKuzzleResponse(sr.Response())
 	result.options = goToCQueryOptions(sr.Options())
@@ -440,8 +454,16 @@ func goToCProfileSearchResult(k *C.kuzzle, sr *security.ProfileSearchResult, err
 	return result
 }
 
-func goToCRoleSearchResult(k *C.kuzzle, sr *security.RoleSearchResult, err error) *C.search_roles_result {
+func goToCRoleSearchResult(k *C.kuzzle, sr *security.RoleSearchResult,
+	err error) *C.search_roles_result {
+	// this situation arises when a next() is performed on the last
+	// search result page
+	if sr == nil && err == nil {
+		return nil
+	}
+
 	result := (*C.search_roles_result)(C.calloc(1, C.sizeof_search_roles_result))
+	result.k = k
 
 	if err != nil {
 		Set_search_roles_result_error(result, err)
@@ -463,7 +485,7 @@ func goToCRoleSearchResult(k *C.kuzzle, sr *security.RoleSearchResult, err error
 	result.scroll_id = C.CString(sr.ScrollId)
 
 	result.instance = unsafe.Pointer(sr)
-	result.k = k
+
 	result.request = goToCKuzzleRequest(sr.Request())
 	result.response = goToCKuzzleResponse(sr.Response())
 	result.options = goToCQueryOptions(sr.Options())
@@ -509,7 +531,15 @@ func goToCQueryOptions(options types.QueryOptions) *C.query_options {
 
 // Allocates memory
 func goToCSearchResult(k *C.kuzzle, sr *types.SearchResult, err error) *C.search_result {
+
+	// this situation arises when a next() is performed on the last
+	// search result page
+	if sr == nil && err == nil {
+		return nil
+	}
+
 	result := (*C.search_result)(C.calloc(1, C.sizeof_search_result))
+	result.k = k
 
 	if err != nil {
 		Set_search_result_error(result, err)
@@ -521,13 +551,11 @@ func goToCSearchResult(k *C.kuzzle, sr *types.SearchResult, err error) *C.search
 	result.total = C.uint(sr.Total)
 	result.fetched = C.uint(sr.Fetched)
 	result.scroll_id = C.CString(sr.ScrollId)
-	result.instance = unsafe.Pointer(sr)
-	result.k = k
 	result.request = goToCKuzzleRequest(sr.Request())
 	result.response = goToCKuzzleResponse(sr.Response())
 	result.options = goToCQueryOptions(sr.Options())
 	result.scroll_action = C.CString(sr.ScrollAction())
-
+	fmt.Printf("result.fetched = %d\n", result.fetched)
 	return result
 }
 
@@ -593,6 +621,12 @@ func goToCSpecificationResult(goRes *types.Specification, err error) *C.specific
 
 // Allocates memory
 func goToCSpecificationSearchResult(goRes *types.SpecificationSearchResult, err error) *C.specification_search_result {
+	// this situation arises when a next() is performed on the last
+	// search result page
+	if goRes == nil && err == nil {
+		return nil
+	}
+
 	result := (*C.specification_search_result)(C.calloc(1, C.sizeof_specification_search_result))
 
 	if err != nil {
@@ -796,7 +830,14 @@ func goToCUserRightsResult(rights []*types.UserRights, err error) *C.user_rights
 }
 
 func goToCUserSearchResult(k *C.kuzzle, sr *security.UserSearchResult, err error) *C.search_users_result {
+	// this situation arises when a next() is performed on the last
+	// search result page
+	if sr == nil && err == nil {
+		return nil
+	}
+
 	result := (*C.search_users_result)(C.calloc(1, C.sizeof_search_users_result))
+	result.k = k
 
 	if err != nil {
 		Set_search_users_result_error(result, err)
@@ -806,19 +847,22 @@ func goToCUserSearchResult(k *C.kuzzle, sr *security.UserSearchResult, err error
 	result.aggregations = C.CString(string(sr.Aggregations))
 	result.hits_length = C.size_t(len(sr.Hits))
 	if len(sr.Hits) > 0 {
-		result.hits = (*C.kuzzle_user)(C.calloc(result.hits_length, C.sizeof_kuzzle_user))
+		result.hits = (*C.kuzzle_user)(C.calloc(
+			result.hits_length,
+			C.sizeof_kuzzle_user))
 		carr := (*[1<<26 - 1]C.kuzzle_user)(unsafe.Pointer(result.hits))[:len(sr.Hits)]
 
 		for i, user := range sr.Hits {
 			goToCUser(k, user, &carr[i])
 		}
 	}
+
 	result.total = C.uint(sr.Total)
 	result.fetched = C.uint(sr.Fetched)
 	result.scroll_id = C.CString(sr.ScrollId)
 
 	result.instance = unsafe.Pointer(sr)
-	result.k = k
+
 	result.request = goToCKuzzleRequest(sr.Request())
 	result.response = goToCKuzzleResponse(sr.Response())
 	result.options = goToCQueryOptions(sr.Options())

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -21,7 +21,6 @@ package main
 
 	static void call_notification_bridge(notification_result* result,
 																			 void* data) {
-		printf("calling bridge_notification...\n");
 		bridge_notification(result, data);
 	}
 
@@ -146,7 +145,6 @@ package main
 	}
 
 	static kuzzle_notification_listener get_bridge_notification_listener_fptr() {
-		printf("go call bridge pointer: %p\n", &call_notification_bridge);
 		return &call_notification_bridge;
 	}
 */
@@ -278,6 +276,7 @@ func (wp WrapProtocol) RegisterSub(channel, roomID string,
 	subscribeToSelf bool,
 	notifChan chan<- types.NotificationResult,
 	onReconnectChannel chan<- interface{}) {
+
 	_list_notification_listeners[channel] = notifChan
 
 	C.bridge_register_sub(wp.P.register_sub, C.CString(channel),

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -262,7 +262,15 @@ func (wp WrapProtocol) State() int {
 }
 
 func (wp WrapProtocol) EmitEvent(event int, data interface{}) {
-	C.bridge_emit_event(wp.P.emit_event, C.int(event), nil, wp.P.instance)
+	str, err := json.Marshal(data)
+
+	if err != nil {
+		str = []byte("")
+	}
+
+	p := unsafe.Pointer(C.CString(string(str)))
+	defer C.free(p)
+	C.bridge_emit_event(wp.P.emit_event, C.int(event), p, wp.P.instance)
 }
 
 //export bridge_notification

--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -77,9 +77,17 @@ func kuzzle_realtime_unsubscribe(rt *C.realtime, roomId *C.char, options *C.quer
 }
 
 //export kuzzle_realtime_subscribe
-func kuzzle_realtime_subscribe(rt *C.realtime, index, collection, body *C.char, callback C.kuzzle_notification_listener, data unsafe.Pointer, options *C.room_options) *C.subscribe_result {
+func kuzzle_realtime_subscribe(rt *C.realtime, index, collection, body *C.char,
+	callback C.kuzzle_notification_listener, data unsafe.Pointer,
+	options *C.room_options) *C.subscribe_result {
+
 	c := make(chan types.NotificationResult)
-	subRes, err := (*realtime.Realtime)(rt.instance).Subscribe(C.GoString(index), C.GoString(collection), json.RawMessage(C.GoString(body)), c, SetRoomOptions(options))
+	subRes, err := (*realtime.Realtime)(rt.instance).Subscribe(
+		C.GoString(index),
+		C.GoString(collection),
+		json.RawMessage(C.GoString(body)),
+		c,
+		SetRoomOptions(options))
 
 	if err != nil {
 		return goToCSubscribeResult(subRes, err)

--- a/cgo/kuzzle/security.go
+++ b/cgo/kuzzle/security.go
@@ -475,7 +475,7 @@ func kuzzle_security_is_action_allowed(crights **C.user_right, crlength C.uint, 
 
 	carray := (*[1<<28 - 1]*C.user_right)(unsafe.Pointer(crights))[:int(crlength):int(crlength)]
 	for i := 0; i < int(crlength); i++ {
-		rights[i] = cToGoUserRigh(carray[i])
+		rights[i] = cToGoUserRight(carray[i])
 	}
 
 	res := security.IsActionAllowed(rights, C.GoString(controller), C.GoString(action), C.GoString(index), C.GoString(collection))

--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -171,7 +171,10 @@ func kuzzle_websocket_close(ws *C.web_socket) *C.char {
 }
 
 //export kuzzle_websocket_register_sub
-func kuzzle_websocket_register_sub(ws *C.web_socket, channel, roomId, filters *C.char, subscribe_to_self C.bool, listener C.kuzzle_notification_listener) {
+func kuzzle_websocket_register_sub(ws *C.web_socket, channel, roomId,
+	filters *C.char, subscribe_to_self C.bool,
+	listener C.kuzzle_notification_listener) {
+
 	c := make(chan types.NotificationResult)
 
 	_notification_listeners[C.GoString(channel)] = c
@@ -182,7 +185,10 @@ func kuzzle_websocket_register_sub(ws *C.web_socket, channel, roomId, filters *C
 				break
 			}
 
-			C.bridge_trigger_notification_listener(listener, goToCNotificationResult(&res), ws.cpp_instance)
+			C.bridge_trigger_notification_listener(
+				listener,
+				goToCNotificationResult(&res),
+				ws.cpp_instance)
 		}
 	}()
 	(*websocket.WebSocket)(ws.instance).RegisterSub(C.GoString(channel), C.GoString(roomId), json.RawMessage(C.GoString(filters)), bool(subscribe_to_self), c, nil)

--- a/include/internal/kuzzle_structs.h
+++ b/include/internal/kuzzle_structs.h
@@ -638,7 +638,6 @@ typedef struct search_result {
     unsigned total;
     unsigned fetched;
     const char *scroll_id;
-    void *instance;
     kuzzle *k;
     kuzzle_request *request;
     kuzzle_response *response;

--- a/include/internal/protocol.h
+++ b/include/internal/protocol.h
@@ -31,7 +31,8 @@ typedef struct {
   const char* (*close)(void*);
   int (*get_state)(void*);
   void (*emit_event)(int, void*, void*);
-  void (*register_sub)(const char*, const char*, const char*, bool, kuzzle_notification_listener*, void*);
+  void (*register_sub)(const char*, const char*, const char*, bool,
+                       kuzzle_notification_listener*, void*);
   void (*unregister_sub)(const char*, void*);
   void (*cancel_subs)(void*);
   void (*start_queuing)(void*);

--- a/include/internal/protocol.h
+++ b/include/internal/protocol.h
@@ -32,7 +32,7 @@ typedef struct {
   int (*get_state)(void*);
   void (*emit_event)(int, void*, void*);
   void (*register_sub)(const char*, const char*, const char*, bool,
-                       kuzzle_notification_listener*, void*);
+                       kuzzle_notification_listener, void*);
   void (*unregister_sub)(const char*, void*);
   void (*cancel_subs)(void*);
   void (*start_queuing)(void*);


### PR DESCRIPTION
# Description

Many stability issues were found by simply calling Kuzzle and Protocol destructors during functional tests.

This PR is **only** the necessary fixes to allow safely unallocating these 2 objects:

* `SearchResult`:
  * Go structs are now entirely rebuilt on-demand from their C counterpart, instead of relying on an `instance` pointer that wasn't saved, and thus could be freed by Go's GC
  * Prevent unnecessary memory allocation (and NULL dereference) when invoking `next` on the last result page
* listeners (kuzzle + websocket):
  * Properly handles once listeners
  * Handles multiple listeners on a same event
  * Do not create channels if a listener is not going to be created
* WebSocket:
  * add a destructor unregistering the Go instance, allowing it to be collected by the GC

# Boyscout

* Apply [Google C++ style](https://google.github.io/styleguide/cppguide.html) where code was changed 
* Fix function name `cToGoUserRigh` => `cToGoUserRight`