### PR TITLE
Fix erroneous pointer on function pointer

### DIFF
--- a/cgo/kuzzle/bridges.c
+++ b/cgo/kuzzle/bridges.c
@@ -14,20 +14,20 @@ void call_notification_bridge(notification_result* result, void* data) {
   bridge_notification(result, data);
 }
 
-void bridge_protocol_add_listener(void (*f)(int, kuzzle_event_listener*, void*),
-                                  int event, kuzzle_event_listener* listener,
+void bridge_protocol_add_listener(void (*f)(int, kuzzle_event_listener, void*),
+                                  int event, kuzzle_event_listener listener,
                                   void* data) {
   f(event, listener, data);
 }
 
-void bridge_protocol_once(void (*f)(int, kuzzle_event_listener*, void*),
-                          int event, kuzzle_event_listener* listener,
+void bridge_protocol_once(void (*f)(int, kuzzle_event_listener, void*),
+                          int event, kuzzle_event_listener listener,
                           void* data) {
   f(event, listener, data);
 }
 
-void bridge_remove_listener(void (*f)(int, kuzzle_event_listener*, void*),
-                            int event, kuzzle_event_listener* listener,
+void bridge_remove_listener(void (*f)(int, kuzzle_event_listener, void*),
+                            int event, kuzzle_event_listener listener,
                             void* data) {
   f(event, listener, data);
 }
@@ -36,8 +36,8 @@ void bridge_remove_all_listeners(void (*f)(int, void*), int event, void* data) {
   f(event, data);
 }
 
-void bridge_once(void (*f)(int, kuzzle_event_listener*, void*), int event,
-                 kuzzle_event_listener* listener, void* data) {
+void bridge_once(void (*f)(int, kuzzle_event_listener, void*), int event,
+                 kuzzle_event_listener listener, void* data) {
   f(event, listener, data);
 }
 

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -60,17 +60,25 @@ func bridge_listener_once(event C.int, res *C.char, data unsafe.Pointer) {
 }
 
 func (wp WrapProtocol) AddListener(event int, channel chan<- json.RawMessage) {
-	fptr := C.get_bridge_fptr()
 	if _list_listeners[event] == nil {
 		_list_listeners[event] = make(map[chan<- json.RawMessage]bool)
 	}
 	_list_listeners[event][channel] = true
-	C.bridge_protocol_add_listener(wp.P.add_listener, C.int(event), &fptr, wp.P.instance)
+
+	C.bridge_protocol_add_listener(
+		wp.P.add_listener,
+		C.int(event),
+		C.get_bridge_fptr(),
+		wp.P.instance)
 }
 
 func (wp WrapProtocol) RemoveListener(event int, channel chan<- json.RawMessage) {
-	fptr := C.get_bridge_fptr()
-	C.bridge_remove_listener(wp.P.remove_listener, C.int(event), &fptr, wp.P.instance)
+	C.bridge_remove_listener(
+		wp.P.remove_listener,
+		C.int(event),
+		C.get_bridge_fptr(),
+		wp.P.instance)
+
 	delete(_list_listeners[event], channel)
 }
 
@@ -79,12 +87,16 @@ func (wp WrapProtocol) RemoveAllListeners(event int) {
 }
 
 func (wp WrapProtocol) Once(event int, channel chan<- json.RawMessage) {
-	fptr := C.get_bridge_once_fptr()
 	if _list_once_listeners[event] == nil {
 		_list_once_listeners[event] = make(map[chan<- json.RawMessage]bool)
 	}
 	_list_once_listeners[event][channel] = true
-	C.bridge_protocol_once(wp.P.once, C.int(event), &fptr, wp.P.instance)
+
+	C.bridge_protocol_once(
+		wp.P.once,
+		C.int(event),
+		C.get_bridge_once_fptr(),
+		wp.P.instance)
 }
 
 func (wp WrapProtocol) ListenerCount(event int) int {

--- a/include/internal/bridges.h
+++ b/include/internal/bridges.h
@@ -4,18 +4,18 @@
 void call_bridge(int event, char* res, void* data);
 void call_bridge_once(int event, char* res, void* data);
 void call_notification_bridge(notification_result* result, void* data);
-void bridge_protocol_add_listener(void (*f)(int, kuzzle_event_listener*, void*),
-                                  int event, kuzzle_event_listener* listener,
+void bridge_protocol_add_listener(void (*f)(int, kuzzle_event_listener, void*),
+                                  int event, kuzzle_event_listener listener,
                                   void* data);
-void bridge_protocol_once(void (*f)(int, kuzzle_event_listener*, void*),
-                          int event, kuzzle_event_listener* listener,
+void bridge_protocol_once(void (*f)(int, kuzzle_event_listener, void*),
+                          int event, kuzzle_event_listener listener,
                           void* data);
-void bridge_remove_listener(void (*f)(int, kuzzle_event_listener*, void*),
-                            int event, kuzzle_event_listener* listener,
+void bridge_remove_listener(void (*f)(int, kuzzle_event_listener, void*),
+                            int event, kuzzle_event_listener listener,
                             void* data);
 void bridge_remove_all_listeners(void (*f)(int, void*), int event, void* data);
-void bridge_once(void (*f)(int, kuzzle_event_listener*, void*), int event,
-                 kuzzle_event_listener* listener, void* data);
+void bridge_once(void (*f)(int, kuzzle_event_listener, void*), int event,
+                 kuzzle_event_listener listener, void* data);
 int bridge_listener_count(int (*f)(int, void*), int event, void* data);
 char* bridge_connect(char* (*f)(void*), void* data);
 kuzzle_response* bridge_send(

--- a/include/internal/protocol.h
+++ b/include/internal/protocol.h
@@ -21,10 +21,10 @@
 typedef struct {
   void* instance;
 
-  void (*add_listener)(int, kuzzle_event_listener*, void*);
-  void (*remove_listener)(int, kuzzle_event_listener*, void*);
+  void (*add_listener)(int, kuzzle_event_listener, void*);
+  void (*remove_listener)(int, kuzzle_event_listener, void*);
   void (*remove_all_listeners)(int, void*);
-  void (*once)(int, kuzzle_event_listener*, void*);
+  void (*once)(int, kuzzle_event_listener, void*);
   int (*listener_count)(int, void*);
   char* (*connect)(void*);
   kuzzle_response* (*send)(const char*, query_options*, char*, void*);


### PR DESCRIPTION
# Description

The `kuzzle_event_listener` type is a typedef of a function pointer. Many bridges functions erroneously used the `kuzzle_event_listener*` type, meaning that they were taking a pointer over a variable storing a function pointer, meaning that dereferencing will not yield to a callable function (not mentioning the address becoming invalid as soon as the referenced variable becomes out of scope)