### PR TITLE
Remove offline queue management from protocol

### DIFF
--- a/cgo/kuzzle/bridges.c
+++ b/cgo/kuzzle/bridges.c
@@ -151,3 +151,7 @@ kuzzle_event_listener get_bridge_once_fptr() {
 kuzzle_notification_listener get_bridge_notification_listener_fptr() {
   return &call_notification_bridge;
 }
+
+bool bridge_is_ready(bool (*f)(void*), void* data) {
+  return f(data);
+}

--- a/cgo/kuzzle/kuzzle.go
+++ b/cgo/kuzzle/kuzzle.go
@@ -304,11 +304,6 @@ func kuzzle_set_auto_replay(k *C.kuzzle, value C.bool) {
 	(*kuzzle.Kuzzle)(k.instance).SetAutoReplay(bool(value))
 }
 
-//export kuzzle_get_host
-func kuzzle_get_host(k *C.kuzzle) *C.char {
-	return C.CString((*kuzzle.Kuzzle)(k.instance).Host())
-}
-
 //export kuzzle_get_offline_queue_loader
 func kuzzle_get_offline_queue_loader(k *C.kuzzle) C.kuzzle_offline_queue_loader {
 	return k.loader
@@ -317,11 +312,6 @@ func kuzzle_get_offline_queue_loader(k *C.kuzzle) C.kuzzle_offline_queue_loader 
 //export kuzzle_set_offline_queue_loader
 func kuzzle_set_offline_queue_loader(k *C.kuzzle, loader C.kuzzle_offline_queue_loader) {
 	k.loader = loader
-}
-
-//export kuzzle_get_port
-func kuzzle_get_port(k *C.kuzzle) C.int {
-	return C.int((*kuzzle.Kuzzle)(k.instance).Port())
 }
 
 //export kuzzle_get_queue_filter

--- a/cgo/kuzzle/protocol.go
+++ b/cgo/kuzzle/protocol.go
@@ -13,8 +13,6 @@ import (
 	"sync"
 	"time"
 	"unsafe"
-
-	"github.com/kuzzleio/sdk-go/protocol"
 	"github.com/kuzzleio/sdk-go/types"
 )
 
@@ -164,26 +162,6 @@ func (wp WrapProtocol) RequestHistory() map[string]time.Time {
 	return nil
 }
 
-func (wp WrapProtocol) StartQueuing() {
-	C.bridge_start_queuing(wp.P.start_queuing, wp.P.instance)
-}
-
-func (wp WrapProtocol) StopQueuing() {
-	C.bridge_stop_queuing(wp.P.stop_queuing, wp.P.instance)
-}
-
-func (wp WrapProtocol) PlayQueue() {
-	C.bridge_play_queue(wp.P.play_queue, wp.P.instance)
-}
-
-func (wp WrapProtocol) ClearQueue() {
-	C.bridge_clear_queue(wp.P.clear_queue, wp.P.instance)
-}
-
-func (wp WrapProtocol) AutoQueue() bool {
-	return bool(C.bridge_is_auto_queue(wp.P.is_auto_queue, wp.P.instance))
-}
-
 func (wp WrapProtocol) AutoReconnect() bool {
 	return bool(C.bridge_is_auto_reconnect(wp.P.is_auto_reconnect, wp.P.instance))
 }
@@ -192,57 +170,8 @@ func (wp WrapProtocol) AutoResubscribe() bool {
 	return bool(C.bridge_is_auto_resubscribe(wp.P.is_auto_resubscribe, wp.P.instance))
 }
 
-// Deprecated
-func (wp WrapProtocol) AutoReplay() bool {
-	//@todo will be moved in Kuzzle object
-	return false
-}
-
-func (wp WrapProtocol) Host() string {
-	return C.GoString(C.bridge_get_host(wp.P.get_host, wp.P.instance))
-}
-
-// Deprecated
-func (wp WrapProtocol) OfflineQueue() []*types.QueryObject {
-	//@todo will be moved in Kuzzle object
-	return nil
-}
-
-// Deprecated
-func (wp WrapProtocol) OfflineQueueLoader() protocol.OfflineQueueLoader {
-	//@todo will be moved in Kuzzle object
-	var offline protocol.OfflineQueueLoader
-	return offline
-}
-
 func (wp WrapProtocol) Port() int {
 	return int(C.bridge_get_port(wp.P.get_port, wp.P.instance))
-}
-
-// Deprecated
-func (wp WrapProtocol) QueueFilter() protocol.QueueFilter {
-	//@todo will be moved in Kuzzle object
-	return func(data []byte) bool {
-		return false
-	}
-}
-
-// Deprecated
-func (wp WrapProtocol) QueueMaxSize() int {
-	//@todo will be moved in Kuzzle object
-	return -1
-}
-
-// Deprecated
-func (wp WrapProtocol) QueueTTL() time.Duration {
-	//@todo will be moved in Kuzzle object
-	return time.Duration(0)
-}
-
-// Deprecated
-func (wp WrapProtocol) ReplayInterval() time.Duration {
-	//@todo will be moved in Kuzzle object
-	return time.Duration(0)
 }
 
 func (wp WrapProtocol) ReconnectionDelay() time.Duration {
@@ -253,37 +182,10 @@ func (wp WrapProtocol) SslConnection() bool {
 	return bool(C.bridge_is_ssl_connection(wp.P.is_ssl_connection, wp.P.instance))
 }
 
-// Deprecated
-func (wp WrapProtocol) SetAutoQueue(value bool) {
-	//@todo will be moved in Kuzzle object
+func (wp WrapProtocol) IsReady() bool {
+	return bool(C.bridge_is_ready(wp.P.is_ready, wp.P.instance))
 }
 
-// Deprecated
-func (wp WrapProtocol) SetAutoReplay(value bool) {
-	//@todo will be moved in Kuzzle object
-}
-
-// Deprecated
-func (wp WrapProtocol) SetOfflineQueueLoader(value protocol.OfflineQueueLoader) {
-	//@todo will be moved in Kuzzle object
-}
-
-// Deprecated
-func (wp WrapProtocol) SetQueueFilter(value protocol.QueueFilter) {
-	//@todo will be moved in Kuzzle object
-}
-
-// Deprecated
-func (wp WrapProtocol) SetQueueMaxSize(value int) {
-	//@todo will be moved in Kuzzle object
-}
-
-// Deprecated
-func (wp WrapProtocol) SetQueueTTL(value time.Duration) {
-	//@todo will be moved in Kuzzle object
-}
-
-// Deprecated
-func (wp WrapProtocol) SetReplayInterval(value time.Duration) {
-	//@todo will be moved in Kuzzle object
+func (wp WrapProtocol) Host() string {
+	return C.GoString(C.bridge_get_host(wp.P.get_host, wp.P.instance))
 }

--- a/cgo/kuzzle/websocket.go
+++ b/cgo/kuzzle/websocket.go
@@ -205,40 +205,10 @@ func kuzzle_websocket_cancel_subs(ws *C.web_socket) {
 	(*websocket.WebSocket)(ws.instance).CancelSubs()
 }
 
-//export kuzzle_websocket_start_queuing
-func kuzzle_websocket_start_queuing(ws *C.web_socket) {
-	(*websocket.WebSocket)(ws.instance).StartQueuing()
-}
-
-//export kuzzle_websocket_stop_queuing
-func kuzzle_websocket_stop_queuing(ws *C.web_socket) {
-	(*websocket.WebSocket)(ws.instance).StopQueuing()
-}
-
-//export kuzzle_websocket_play_queue
-func kuzzle_websocket_play_queue(ws *C.web_socket) {
-	(*websocket.WebSocket)(ws.instance).PlayQueue()
-}
-
-//export kuzzle_websocket_clear_queue
-func kuzzle_websocket_clear_queue(ws *C.web_socket) {
-	(*websocket.WebSocket)(ws.instance).ClearQueue()
-}
-
 //export kuzzle_websocket_remove_all_listeners
 func kuzzle_websocket_remove_all_listeners(ws *C.web_socket, event C.int) {
 	(*websocket.WebSocket)(ws.instance).RemoveAllListeners(int(event))
 	delete(_event_listeners, int(event))
-}
-
-//export kuzzle_websocket_is_auto_reconnect
-func kuzzle_websocket_is_auto_reconnect(ws *C.web_socket) C.bool {
-	return C.bool((*websocket.WebSocket)(ws.instance).AutoReconnect())
-}
-
-//export kuzzle_websocket_is_auto_resubscribe
-func kuzzle_websocket_is_auto_resubscribe(ws *C.web_socket) C.bool {
-	return C.bool((*websocket.WebSocket)(ws.instance).AutoResubscribe())
 }
 
 //export kuzzle_websocket_get_host
@@ -249,11 +219,6 @@ func kuzzle_websocket_get_host(ws *C.web_socket) *C.char {
 //export kuzzle_websocket_get_port
 func kuzzle_websocket_get_port(ws *C.web_socket) C.int {
 	return C.int((*websocket.WebSocket)(ws.instance).Port())
-}
-
-//export kuzzle_websocket_get_reconnection_delay
-func kuzzle_websocket_get_reconnection_delay(ws *C.web_socket) C.int {
-	return C.int((*websocket.WebSocket)(ws.instance).ReconnectionDelay())
 }
 
 //export kuzzle_websocket_is_ssl_connection

--- a/include/internal/bridges.h
+++ b/include/internal/bridges.h
@@ -55,4 +55,6 @@ kuzzle_event_listener get_bridge_fptr();
 kuzzle_event_listener get_bridge_once_fptr();
 kuzzle_notification_listener get_bridge_notification_listener_fptr();
 
+bool bridge_is_ready(bool (*f)(void*), void* data);
+
 #endif

--- a/include/internal/protocol.h
+++ b/include/internal/protocol.h
@@ -35,19 +35,14 @@ typedef struct {
                        kuzzle_notification_listener, void*);
   void (*unregister_sub)(const char*, void*);
   void (*cancel_subs)(void*);
-  void (*start_queuing)(void*);
-  void (*stop_queuing)(void*);
-  void (*play_queue)(void*);
-  void (*clear_queue)(void*);
 
-  bool (*is_auto_queue)(void*);
   bool (*is_auto_reconnect)(void*);
   bool (*is_auto_resubscribe)(void*);
   const char* (*get_host)(void*);
   unsigned int (*get_port)(void*);
   unsigned long long (*get_reconnection_delay)(void*);
   bool (*is_ssl_connection)(void*);
-
+  bool (*is_ready)(void*);
 } protocol;
 
 #endif


### PR DESCRIPTION
## What does this PR do ?

Remove offline queue management from Protocol.

Depends on https://github.com/kuzzleio/sdk-go/pull/238