### PR TITLE
[fix] Fix compilation with Go version >=1.11.1

### DIFF
--- a/cgo/kuzzle/realtime.go
+++ b/cgo/kuzzle/realtime.go
@@ -17,7 +17,7 @@ package main
 /*
 	#cgo CFLAGS: -I../../include
 	#include "internal/kuzzle_structs.h"
-    #include "internal/sdk_wrappers_internal.h"
+	#include "internal/sdk_wrappers_internal.h"
 */
 import "C"
 

--- a/cgo/kuzzle/server.go
+++ b/cgo/kuzzle/server.go
@@ -16,8 +16,6 @@ package main
 
 /*
 	#cgo CFLAGS: -I../../include
-	#include <errno.h>
-	#include <stdlib.h>
 	#include "internal/kuzzle_structs.h"
 	#include "internal/sdk_wrappers_internal.h"
 */


### PR DESCRIPTION

![idk](https://user-images.githubusercontent.com/7868838/53743178-83491000-3e9a-11e9-8f10-4be8ce281b89.jpg)



## What does this PR do ?
I finally find a way to make the sdk-cpp compile with Go version up to 1.11.0. But I really don't know what happens. 