### PR TITLE
Fix a crash when a realtime notification has a null content

### DIFF
--- a/cgo/kuzzle/go_to_c.go
+++ b/cgo/kuzzle/go_to_c.go
@@ -70,6 +70,10 @@ func goToCShards(gShards *types.Shards) *C.shards {
 
 // Allocates memory
 func goToCNotificationContent(gNotifContent *types.NotificationContent) *C.notification_content {
+	if gNotifContent == nil {
+		return nil
+	}
+
 	result := (*C.notification_content)(C.calloc(1, C.sizeof_notification_content))
 	result.id = C.CString(gNotifContent.Id)
 	result.m = goToCMeta(gNotifContent.Meta)


### PR DESCRIPTION
# Description

The C SDK crashes whenever a realtime notification without a `content` property is sent by Kuzzle.
This happens, for instance, when a `TokenExpired` event notification is sent.

# How to test

The following code makes the SDK crash without this fix:

```cpp
#include <iostream>
#include <unistd.h>
#include "websocket.hpp"
#include "kuzzle.hpp"

int main(void) {
  auto *ws = new kuzzleio::WebSocket("kuzzle");
  auto *kuzzle = new kuzzleio::Kuzzle(ws);

  kuzzle->connect();
  kuzzle->auth->login("local",
    R"({"username":"foobar","password":"foobar"})", 1000);

  kuzzleio::NotificationListener listener =
    [](const std::shared_ptr<kuzzleio::notification_result> &notification) {
      std::cout << notification->result->content << std::endl;
    };

  kuzzle->realtime->subscribe("foo","bar","{}", &listener);

  kuzzle->realtime->publish("foo", "bar", R"%({"foo": "bar"})%");

  // Waiting for the auth token to expire
  sleep(3);

  return 0;
}
```